### PR TITLE
use raw sockets on select platforms

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -225,6 +225,10 @@ async fn main() -> Result<()> {
 
     let icmp_identifier = std::process::id() as u16;
 
+    #[cfg(not(any(target_os="macos", target_os="windows")))]
+    let socket = Socket::new(Domain::IPV4, Type::RAW, Some(Protocol::ICMPV4))
+        .context("Failed to create ICMP DGRAM socket.")?;
+    #[cfg(any(target_os="macos", target_os="windows"))]
     let socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::ICMPV4))
         .context("Failed to create ICMP DGRAM socket.")?;
     let bind_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);


### PR DESCRIPTION
Hello,

When checking this out on FreeBSD I saw errors like the following when trying to trace hosts

```
Error: Failed to create ICMP DGRAM socket.

Caused by:
    Protocol not supported (os error 43)
```

The suggested fix uses raw sockets on platforms where datagram sockets for ICMP protocol does not appear available.

I also checked on a musl-based Linux distribution and had similar protocol errors  so am not sure if a glibc-based Linux will behave differently.
