### PR TITLE
perf: optimize CI by using pre-built binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
-    - name: Install tarpaulin
-      run: cargo install cargo-tarpaulin
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-tarpaulin
     - name: Run coverage
       run: cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml --exclude-files "*/tests/*" --exclude-files "*/examples/*"
     - name: Upload coverage to Codecov
@@ -86,8 +87,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
-    - name: Install cargo-machete
-      run: cargo install cargo-machete
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-machete
     - name: Check unused dependencies
       run: cargo machete
 
@@ -97,8 +99,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
-    - name: Install cargo-outdated
-      run: cargo install cargo-outdated
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-outdated
     - name: Check outdated dependencies
       run: cargo outdated --exit-code 1 || echo "::warning::Outdated dependencies found"
 


### PR DESCRIPTION
## Summary
Replace slow cargo install commands with taiki-e/install-action which downloads pre-built binaries when available.

## Problem
The cargo-outdated installation step was taking over 5 minutes in CI, making the overall CI run very slow.

## Solution
Use the taiki-e/install-action GitHub Action which:
- Downloads pre-built binaries when available (seconds)
- Falls back to cargo install only when necessary
- Is widely used and well-maintained
- Supports cargo-tarpaulin, cargo-machete, and cargo-outdated

## Expected Impact
- cargo-outdated: 5+ minutes → ~10 seconds
- cargo-tarpaulin: 2-3 minutes → ~10 seconds  
- cargo-machete: 1-2 minutes → ~10 seconds

This should significantly speed up CI runs, especially for PRs.