### PR TITLE
fix: Honor injected services/servers, remove env-var signaling, harden DNS resolver

### DIFF
--- a/src/dns/resolver.rs
+++ b/src/dns/resolver.rs
@@ -5,7 +5,7 @@
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tokio::net::UdpSocket;
-use tokio::time::{timeout, Duration};
+use tokio::time::Duration;
 
 /// DNS query types
 #[derive(Debug, Clone, Copy)]
@@ -41,11 +41,23 @@ pub enum DnsError {
     /// No records found
     #[error("no records found (NXDOMAIN or empty)")]
     NotFound,
+    /// Response was truncated (TC bit set)
+    ///
+    /// The answer did not fit in a UDP datagram. Retrying the query over
+    /// TCP is future work; callers currently treat this as a failed lookup.
+    #[error("truncated DNS response (TCP fallback not implemented)")]
+    Truncated,
 }
 
-/// Cloudflare DNS server
-const DNS_SERVER: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 53);
-/// DNS query timeout
+/// Public resolvers tried in order: Cloudflare primary, Google fallback.
+/// The fallback is only consulted when the primary times out or errors,
+/// not on an authoritative NXDOMAIN.
+const DNS_SERVERS: &[SocketAddr] = &[
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 53),
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
+];
+/// Per-server DNS query timeout. If no response arrives halfway through
+/// this window, the query is retransmitted once (UDP datagrams may be lost).
 const DNS_TIMEOUT: Duration = Duration::from_secs(5);
 /// Maximum DNS response size
 const MAX_RESPONSE: usize = 4096;
@@ -110,27 +122,99 @@ pub async fn resolve_txt(name: &str) -> Result<Vec<String>, DnsError> {
     Ok(txts)
 }
 
-/// Send a DNS query and parse the response.
+/// Send a DNS query and parse the response, trying each configured server
+/// in order until one yields an answer (or an authoritative NXDOMAIN).
 async fn query(name: &str, qtype: QType) -> Result<Vec<DnsRecord>, DnsError> {
-    let packet = build_query(name, qtype);
-
-    let socket = UdpSocket::bind("0.0.0.0:0").await?;
-    socket.send_to(&packet, DNS_SERVER).await?;
-
-    let mut buf = vec![0u8; MAX_RESPONSE];
-    let n = timeout(DNS_TIMEOUT, socket.recv(&mut buf))
-        .await
-        .map_err(|_| DnsError::Timeout)??;
-
-    parse_response(&buf[..n], qtype)
+    let mut last_err = DnsError::Timeout;
+    for server in DNS_SERVERS {
+        match query_server(name, qtype, *server).await {
+            Ok(records) => return Ok(records),
+            // NXDOMAIN is an authoritative answer; asking another
+            // recursive resolver would just repeat it.
+            Err(DnsError::NotFound) => return Err(DnsError::NotFound),
+            Err(e) => last_err = e,
+        }
+    }
+    Err(last_err)
 }
 
-/// Build a DNS query packet.
-fn build_query(name: &str, qtype: QType) -> Vec<u8> {
+/// Send a DNS query to a single server and parse the response.
+///
+/// Retransmits once halfway through [`DNS_TIMEOUT`] if no response has
+/// arrived, and discards datagrams whose header does not match our query
+/// (wrong ID, or not a response) until the deadline.
+async fn query_server(
+    name: &str,
+    qtype: QType,
+    server: SocketAddr,
+) -> Result<Vec<DnsRecord>, DnsError> {
+    let id = random_query_id();
+    let packet = build_query(name, qtype, id);
+
+    let socket = UdpSocket::bind("0.0.0.0:0").await?;
+    // Connecting also makes the OS drop datagrams from other source addresses
+    socket.connect(server).await?;
+    socket.send(&packet).await?;
+
+    let deadline = tokio::time::Instant::now() + DNS_TIMEOUT;
+    // One retransmission halfway through the timeout window
+    let mut retransmit_at = Some(tokio::time::Instant::now() + DNS_TIMEOUT / 2);
+    let mut buf = vec![0u8; MAX_RESPONSE];
+
+    loop {
+        let wait_until = retransmit_at.unwrap_or(deadline);
+        match tokio::time::timeout_at(wait_until, socket.recv(&mut buf)).await {
+            Ok(Ok(n)) => {
+                // Ignore datagrams that are not a response to our query
+                // (mismatched ID or QR bit clear); keep listening.
+                if !is_matching_response(&buf[..n], id) {
+                    continue;
+                }
+                return parse_response(&buf[..n], qtype);
+            }
+            Ok(Err(e)) => return Err(DnsError::Io(e)),
+            Err(_) => {
+                // Timer fired: retransmit once, then give up at the deadline
+                if retransmit_at.take().is_some() {
+                    socket.send(&packet).await?;
+                } else {
+                    return Err(DnsError::Timeout);
+                }
+            }
+        }
+    }
+}
+
+/// Generate a random DNS query ID, used to match responses to requests.
+fn random_query_id() -> u16 {
+    let mut bytes = [0u8; 2];
+    if getrandom::fill(&mut bytes).is_ok() {
+        u16::from_be_bytes(bytes)
+    } else {
+        // Fallback: derive from the clock. Matching responses to requests is
+        // the primary goal; the connected socket already restricts who can
+        // send us datagrams.
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos();
+        (nanos & 0xFFFF) as u16 ^ (nanos >> 16) as u16
+    }
+}
+
+/// Check whether a datagram is a response (QR bit set) to the query with
+/// the given ID. Datagrams failing this check should be discarded, not
+/// treated as errors.
+fn is_matching_response(data: &[u8], id: u16) -> bool {
+    data.len() >= 12 && u16::from_be_bytes([data[0], data[1]]) == id && data[2] & 0x80 != 0
+    // QR bit: must be a response, not a query
+}
+
+/// Build a DNS query packet with the given query ID.
+fn build_query(name: &str, qtype: QType, id: u16) -> Vec<u8> {
     let mut pkt = Vec::with_capacity(64);
 
     // Header: ID, flags, counts
-    let id: u16 = (std::process::id() as u16) ^ (qtype as u16);
     pkt.extend_from_slice(&id.to_be_bytes()); // ID
     pkt.extend_from_slice(&[0x01, 0x00]); // flags: RD=1
     pkt.extend_from_slice(&1u16.to_be_bytes()); // QDCOUNT=1
@@ -153,6 +237,13 @@ fn build_query(name: &str, qtype: QType) -> Vec<u8> {
 fn parse_response(data: &[u8], qtype: QType) -> Result<Vec<DnsRecord>, DnsError> {
     if data.len() < 12 {
         return Err(DnsError::Malformed);
+    }
+
+    // TC (truncation) bit: the full answer did not fit in this datagram.
+    // Silently parsing a partial answer set would be wrong; surface a
+    // distinct error instead (TCP fallback is future work).
+    if data[2] & 0x02 != 0 {
+        return Err(DnsError::Truncated);
     }
 
     // Check RCODE in flags
@@ -369,8 +460,9 @@ mod tests {
 
     #[test]
     fn test_build_query_structure() {
-        let pkt = build_query("example.com", QType::A);
+        let pkt = build_query("example.com", QType::A, 0x1234);
         assert!(pkt.len() > 12);
+        assert_eq!(&pkt[0..2], &[0x12, 0x34]); // ID
         assert_eq!(pkt[2], 0x01); // RD=1
         assert_eq!(pkt[5], 1); // QDCOUNT=1
                                // QTYPE at end - 4 should be A=1
@@ -380,7 +472,7 @@ mod tests {
 
     #[test]
     fn test_build_query_labels() {
-        let pkt = build_query("a.b.c", QType::Txt);
+        let pkt = build_query("a.b.c", QType::Txt, 0x1234);
         assert_eq!(pkt[12], 1);
         assert_eq!(pkt[13], b'a');
         assert_eq!(pkt[14], 1);
@@ -392,7 +484,7 @@ mod tests {
 
     #[test]
     fn test_build_query_single_label() {
-        let pkt = build_query("localhost", QType::A);
+        let pkt = build_query("localhost", QType::A, 0x1234);
         assert_eq!(pkt[12], 9); // "localhost" is 9 chars
         assert_eq!(&pkt[13..22], b"localhost");
         assert_eq!(pkt[22], 0); // root
@@ -492,6 +584,43 @@ mod tests {
             DnsRecord::Txt(s) => assert_eq!(s, ""),
             other => panic!("expected TXT record, got {other:?}"),
         }
+    }
+
+    // ---- response header validation ----
+
+    #[test]
+    fn test_response_id_mismatch_rejected() {
+        // build_response uses ID 0xABCD
+        let resp = build_response("example.com", QType::A, &[(1, &[1, 2, 3, 4])]);
+        assert!(is_matching_response(&resp, 0xABCD));
+        assert!(
+            !is_matching_response(&resp, 0x1234),
+            "a response with a mismatched ID must be discarded"
+        );
+    }
+
+    #[test]
+    fn test_query_packet_not_accepted_as_response() {
+        // A query (QR bit clear) must not be mistaken for a response,
+        // even when the ID matches
+        let pkt = build_query("example.com", QType::A, 0x1234);
+        assert!(!is_matching_response(&pkt, 0x1234));
+    }
+
+    #[test]
+    fn test_short_datagram_not_accepted_as_response() {
+        assert!(!is_matching_response(&[], 0xABCD));
+        assert!(!is_matching_response(&[0xAB, 0xCD], 0xABCD));
+    }
+
+    #[test]
+    fn test_truncated_response_detected() {
+        let mut resp = build_response("example.com", QType::A, &[(1, &[1, 2, 3, 4])]);
+        resp[2] |= 0x02; // set TC bit
+        assert!(matches!(
+            parse_response(&resp, QType::A),
+            Err(DnsError::Truncated)
+        ));
     }
 
     // ---- parse_response: error cases ----
@@ -675,6 +804,7 @@ mod tests {
         assert!(DnsError::Timeout.to_string().contains("timed out"));
         assert!(DnsError::Malformed.to_string().contains("malformed"));
         assert!(DnsError::NotFound.to_string().contains("no records"));
+        assert!(DnsError::Truncated.to_string().contains("truncated"));
         let io_err = DnsError::Io(std::io::Error::new(std::io::ErrorKind::Other, "test"));
         assert!(io_err.to_string().contains("test"));
     }

--- a/src/enrichment/service.rs
+++ b/src/enrichment/service.rs
@@ -31,9 +31,17 @@ pub struct EnrichmentService {
 }
 
 impl EnrichmentService {
-    /// Create a new async enrichment service
+    /// Create a new async enrichment service with fresh default services
     pub async fn new() -> Result<Self, TracerouteError> {
-        let services = Arc::new(Services::new());
+        Self::new_with_services(Arc::new(Services::new())).await
+    }
+
+    /// Create a new async enrichment service backed by the provided services
+    ///
+    /// All DNS and ASN lookups performed during enrichment go through
+    /// `services`, so any caches owned by those services (e.g. pre-warmed
+    /// via [`crate::Ftr::with_caches`]) are honored.
+    pub async fn new_with_services(services: Arc<Services>) -> Result<Self, TracerouteError> {
         let (enrichment_tx, enrichment_rx) = mpsc::unbounded_channel();
 
         Ok(Self {
@@ -276,6 +284,49 @@ mod tests {
 
         // But DNS lookup should work
         assert_eq!(result.addr, ipv6_addr);
+    }
+
+    #[tokio::test]
+    async fn test_enrichment_uses_injected_services() {
+        use crate::asn::cache::AsnCache;
+        use crate::dns::cache::RdnsCache;
+
+        let addr: IpAddr = "8.8.8.8".parse().expect("valid IP");
+
+        // Pre-warm caches with sentinel values. Cache hits are served before
+        // any network I/O, so this test is deterministic and offline-safe:
+        // if the injected services were ignored (the old bug), enrichment
+        // would perform live lookups and never return these sentinels.
+        let asn_cache = AsnCache::new();
+        asn_cache.insert(
+            "8.8.8.0/24".parse().expect("valid prefix"),
+            AsnInfo {
+                asn: 64512,
+                name: "SENTINEL-AS".to_string(),
+                prefix: "8.8.8.0/24".to_string(),
+                country_code: "ZZ".to_string(),
+                registry: "test".to_string(),
+            },
+        );
+        let rdns_cache = RdnsCache::with_default_ttl();
+        rdns_cache.insert(addr, "sentinel.rdns.test".to_string());
+
+        let services = Arc::new(Services::with_caches(
+            Some(asn_cache),
+            Some(rdns_cache),
+            None,
+        ));
+        let service = EnrichmentService::new_with_services(services)
+            .await
+            .expect("service creation");
+
+        let results = service.enrich_addresses(vec![addr]).await;
+        let result = results.get(&addr).expect("result for address");
+
+        assert_eq!(result.hostname.as_deref(), Some("sentinel.rdns.test"));
+        let asn = result.asn_info.as_ref().expect("ASN info from cache");
+        assert_eq!(asn.asn, 64512);
+        assert_eq!(asn.name, "SENTINEL-AS");
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,27 @@ impl Ftr {
         }
     }
 
+    /// Create a new Ftr instance using the provided services
+    ///
+    /// This allows customizing individual services, e.g. a
+    /// [`StunClient`](crate::public_ip::StunClient) configured with custom
+    /// STUN servers.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ftr::services::Services;
+    /// use ftr::public_ip::StunClient;
+    /// use ftr::Ftr;
+    ///
+    /// let stun = StunClient::with_servers(vec!["stun.example.com:3478".to_string()]);
+    /// let services = Services::with_services(None, None, Some(stun));
+    /// let ftr = Ftr::with_services(services);
+    /// ```
+    pub fn with_services(services: Services) -> Self {
+        Self { services }
+    }
+
     /// Create a new Ftr instance with optional pre-initialized caches
     ///
     /// Any cache not provided will be created fresh.

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,19 +174,25 @@ fn main() {
 async fn async_main(_process_start: Instant) -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
-    // Create Ftr instance with fresh caches
-    let ftr_instance = ftr::Ftr::new();
-
-    // Handle public IP option - skip STUN if provided
-    if args.public_ip.is_none() {
-        // Set custom STUN server if provided
-        if let Some(stun_server) = &args.stun_server {
-            std::env::set_var("FTR_STUN_SERVER", stun_server);
-        }
-
-        // Pre-warm STUN cache immediately for faster public IP detection
-        // (Cache warming is now handled internally by Ftr instance)
-    }
+    // Create Ftr instance with fresh caches. If a custom STUN server was
+    // provided, it is tried first with the default servers as fallback
+    // (STUN is only used when no public IP is supplied on the command line).
+    let ftr_instance = if let Some(stun_server) = &args.stun_server {
+        let mut stun_servers = vec![stun_server.clone()];
+        stun_servers.extend(
+            ftr::public_ip::stun::STUN_SERVERS
+                .iter()
+                .map(|s| (*s).to_string()),
+        );
+        let stun = ftr::public_ip::StunClient::with_servers(stun_servers);
+        ftr::Ftr::with_services(ftr::services::Services::with_services(
+            None,
+            None,
+            Some(stun),
+        ))
+    } else {
+        ftr::Ftr::new()
+    };
 
     // Initialize debug mode if requested
     // ftr::debug::init_debug(args.verbose);

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,21 +177,25 @@ async fn async_main(_process_start: Instant) -> Result<(), Box<dyn std::error::E
     // Create Ftr instance with fresh caches. If a custom STUN server was
     // provided, it is tried first with the default servers as fallback
     // (STUN is only used when no public IP is supplied on the command line).
-    let ftr_instance = if let Some(stun_server) = &args.stun_server {
-        let mut stun_servers = vec![stun_server.clone()];
+    // Verbosity is threaded through explicitly, never via environment
+    // variables.
+    let ftr_instance = {
+        let mut stun_servers: Vec<String> = Vec::new();
+        if let Some(stun_server) = &args.stun_server {
+            stun_servers.push(stun_server.clone());
+        }
         stun_servers.extend(
             ftr::public_ip::stun::STUN_SERVERS
                 .iter()
                 .map(|s| (*s).to_string()),
         );
-        let stun = ftr::public_ip::StunClient::with_servers(stun_servers);
+        let stun =
+            ftr::public_ip::StunClient::with_servers(stun_servers).with_verbose(args.verbose);
         ftr::Ftr::with_services(ftr::services::Services::with_services(
             None,
             None,
             Some(stun),
         ))
-    } else {
-        ftr::Ftr::new()
     };
 
     // Initialize debug mode if requested

--- a/src/public_ip/service.rs
+++ b/src/public_ip/service.rs
@@ -3,7 +3,7 @@
 //! This module provides a service-oriented API for STUN-based public IP detection,
 //! abstracting away the server address caching implementation details.
 
-use super::stun::{get_public_ip_stun_with_fallback_and_cache, StunError};
+use super::stun::{get_public_ip_stun_with_servers_and_cache, StunError, STUN_SERVERS};
 use super::stun_cache::StunCache;
 use super::PublicIpError;
 use std::net::IpAddr;
@@ -40,19 +40,19 @@ pub struct StunClient {
 }
 
 impl StunClient {
-    /// Create a new STUN client with default servers
+    /// Create a new STUN client with the default servers
     ///
-    /// Uses Google's STUN servers by default:
-    /// - stun.l.google.com:19302
-    /// - stun1.l.google.com:19302
+    /// Uses the well-known public servers in
+    /// [`STUN_SERVERS`](crate::public_ip::stun::STUN_SERVERS)
+    /// (Google primary and backup, Cloudflare fallback).
     pub fn new() -> Self {
-        Self::with_servers(vec![
-            "stun.l.google.com:19302".to_string(),
-            "stun1.l.google.com:19302".to_string(),
-        ])
+        Self::with_servers(STUN_SERVERS.iter().map(|s| (*s).to_string()).collect())
     }
 
     /// Create a STUN client with custom servers
+    ///
+    /// Servers are tried in order: the first is the primary and the rest
+    /// are fallbacks used only if earlier servers fail.
     ///
     /// # Arguments
     ///
@@ -91,16 +91,16 @@ impl StunClient {
 
     /// Get the public IP address
     ///
-    /// Queries STUN servers to determine the public IP address as seen
-    /// from the internet. This is useful for detecting the external IP
-    /// when behind NAT.
+    /// Queries the configured STUN servers (in order) to determine the
+    /// public IP address as seen from the internet. This is useful for
+    /// detecting the external IP when behind NAT.
     ///
     /// # Returns
     ///
     /// The public IP address (IPv4 or IPv6), or an error if all
     /// STUN servers fail or timeout.
     pub async fn get_public_ip(&self) -> Result<IpAddr, PublicIpError> {
-        get_public_ip_stun_with_fallback_and_cache(self.timeout, &self.cache)
+        get_public_ip_stun_with_servers_and_cache(&self.servers, self.timeout, &self.cache)
             .await
             .map_err(|e| match e {
                 StunError::Timeout => PublicIpError::Timeout,
@@ -181,8 +181,8 @@ mod tests {
     async fn test_stun_client_default() {
         let client = StunClient::new();
 
-        // Should have default Google STUN servers
-        assert_eq!(client.servers().len(), 2);
+        // Should have the default well-known STUN servers
+        assert_eq!(client.servers().len(), STUN_SERVERS.len());
         assert!(client.servers()[0].contains("google.com"));
     }
 
@@ -202,7 +202,23 @@ mod tests {
         let client = StunClient::new().with_timeout(Duration::from_secs(2));
 
         // Timeout is set internally, we can only test that the method works
-        assert_eq!(client.servers().len(), 2);
+        assert_eq!(client.servers().len(), STUN_SERVERS.len());
+    }
+
+    #[tokio::test]
+    async fn test_custom_servers_are_queried() {
+        // A client configured with only an unresolvable custom server must
+        // fail: if the query path ignored the configured servers (the old
+        // bug) and used the hardcoded defaults, this would succeed on any
+        // machine with internet access.
+        let client = StunClient::with_servers(vec!["stun.does-not-exist.invalid:3478".to_string()])
+            .with_timeout(Duration::from_millis(200));
+
+        let result = client.get_public_ip().await;
+        assert!(
+            result.is_err(),
+            "custom unresolvable server must not fall back to default servers"
+        );
     }
 
     #[tokio::test]

--- a/src/public_ip/service.rs
+++ b/src/public_ip/service.rs
@@ -37,6 +37,7 @@ pub struct StunClient {
     cache: Arc<RwLock<StunCache>>,
     servers: Vec<String>,
     timeout: Duration,
+    verbose: u8,
 }
 
 impl StunClient {
@@ -62,6 +63,7 @@ impl StunClient {
             cache: Arc::new(RwLock::new(StunCache::new())),
             servers,
             timeout: Duration::from_millis(500),
+            verbose: 0,
         }
     }
 
@@ -72,6 +74,19 @@ impl StunClient {
     /// * `timeout` - Maximum time to wait for a STUN response
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
+        self
+    }
+
+    /// Set the verbosity level for STUN diagnostics
+    ///
+    /// Levels 2 and above print per-server diagnostics to stderr.
+    /// This replaces the former FTR_VERBOSE environment variable lookup.
+    ///
+    /// # Arguments
+    ///
+    /// * `verbose` - Verbosity level (0 = silent)
+    pub fn with_verbose(mut self, verbose: u8) -> Self {
+        self.verbose = verbose;
         self
     }
 
@@ -86,6 +101,7 @@ impl StunClient {
             cache: Arc::new(RwLock::new(cache)),
             servers,
             timeout: Duration::from_millis(500),
+            verbose: 0,
         }
     }
 
@@ -100,18 +116,23 @@ impl StunClient {
     /// The public IP address (IPv4 or IPv6), or an error if all
     /// STUN servers fail or timeout.
     pub async fn get_public_ip(&self) -> Result<IpAddr, PublicIpError> {
-        get_public_ip_stun_with_servers_and_cache(&self.servers, self.timeout, &self.cache)
-            .await
-            .map_err(|e| match e {
-                StunError::Timeout => PublicIpError::Timeout,
-                StunError::IoError(err) => PublicIpError::HttpError(err.to_string()),
-                StunError::InvalidResponse => {
-                    PublicIpError::ParseError("Invalid STUN response".to_string())
-                }
-                StunError::NoMappedAddress => {
-                    PublicIpError::ParseError("No mapped address in STUN response".to_string())
-                }
-            })
+        get_public_ip_stun_with_servers_and_cache(
+            &self.servers,
+            self.timeout,
+            &self.cache,
+            self.verbose,
+        )
+        .await
+        .map_err(|e| match e {
+            StunError::Timeout => PublicIpError::Timeout,
+            StunError::IoError(err) => PublicIpError::HttpError(err.to_string()),
+            StunError::InvalidResponse => {
+                PublicIpError::ParseError("Invalid STUN response".to_string())
+            }
+            StunError::NoMappedAddress => {
+                PublicIpError::ParseError("No mapped address in STUN response".to_string())
+            }
+        })
     }
 
     /// Get the list of configured STUN servers

--- a/src/public_ip/service.rs
+++ b/src/public_ip/service.rs
@@ -43,8 +43,7 @@ pub struct StunClient {
 impl StunClient {
     /// Create a new STUN client with the default servers
     ///
-    /// Uses the well-known public servers in
-    /// [`STUN_SERVERS`](crate::public_ip::stun::STUN_SERVERS)
+    /// Uses the well-known public servers in [`STUN_SERVERS`]
     /// (Google primary and backup, Cloudflare fallback).
     pub fn new() -> Self {
         Self::with_servers(STUN_SERVERS.iter().map(|s| (*s).to_string()).collect())

--- a/src/public_ip/stun.rs
+++ b/src/public_ip/stun.rs
@@ -140,29 +140,29 @@ async fn get_public_ip_stun_addr(
     parse_stun_response(&buf[..size])
 }
 
-/// Get public IP using STUN with fallback to multiple servers (with injected cache)
+/// Get public IP using STUN with fallback to the default servers (with injected cache)
+///
+/// Tries each server in [`STUN_SERVERS`] in order. To use a custom server
+/// list, see [`get_public_ip_stun_with_servers_and_cache`].
 pub async fn get_public_ip_stun_with_fallback_and_cache(
     timeout: Duration,
     cache: &Arc<RwLock<crate::public_ip::stun_cache::StunCache>>,
 ) -> Result<IpAddr, StunError> {
-    // Pre-warm cache if not already done (this is fast if already cached)
-    let _ = crate::public_ip::stun_cache::prewarm_stun_cache_with_cache(cache).await;
+    let servers: Vec<String> = STUN_SERVERS.iter().map(|s| (*s).to_string()).collect();
+    get_public_ip_stun_with_servers_and_cache(&servers, timeout, cache).await
+}
 
-    // Check for custom STUN server from environment
-    if let Ok(custom_server) = std::env::var("FTR_STUN_SERVER") {
-        if let Ok(ip) = get_public_ip_stun_with_cache(&custom_server, timeout, cache).await {
-            return Ok(ip);
-        }
-        // If custom server fails, fall back to default servers
-    }
-
-    // Try primary server first (Google's is most reliable)
-    if let Ok(ip) = get_public_ip_stun_with_cache(STUN_SERVERS[0], timeout, cache).await {
-        return Ok(ip);
-    }
-
-    // Fall back to other servers
-    for server in &STUN_SERVERS[1..] {
+/// Get public IP using STUN, trying the provided servers in order (with injected cache)
+///
+/// The first server is the primary; the remaining servers are fallbacks
+/// tried only if earlier ones fail. Server addresses are resolved through
+/// (and cached in) the provided cache on demand.
+pub async fn get_public_ip_stun_with_servers_and_cache(
+    servers: &[String],
+    timeout: Duration,
+    cache: &Arc<RwLock<crate::public_ip::stun_cache::StunCache>>,
+) -> Result<IpAddr, StunError> {
+    for server in servers {
         match get_public_ip_stun_with_cache(server, timeout, cache).await {
             Ok(ip) => return Ok(ip),
             Err(_) => continue, // Try next server

--- a/src/public_ip/stun.rs
+++ b/src/public_ip/stun.rs
@@ -60,11 +60,17 @@ pub async fn get_public_ip_stun_with_cache(
     timeout: Duration,
     cache: &Arc<RwLock<crate::public_ip::stun_cache::StunCache>>,
 ) -> Result<IpAddr, StunError> {
-    let verbose = std::env::var("FTR_VERBOSE")
-        .ok()
-        .and_then(|v| v.parse::<u8>().ok())
-        .unwrap_or(0);
+    get_public_ip_stun_with_cache_and_verbose(server, timeout, cache, 0).await
+}
 
+/// Get public IP using STUN protocol with injected cache and an explicit
+/// verbosity level (2+ prints per-server diagnostics to stderr)
+pub async fn get_public_ip_stun_with_cache_and_verbose(
+    server: &str,
+    timeout: Duration,
+    cache: &Arc<RwLock<crate::public_ip::stun_cache::StunCache>>,
+    verbose: u8,
+) -> Result<IpAddr, StunError> {
     if verbose >= 2 {
         eprintln!("[STUN] Attempting to contact STUN server: {}", server);
     }
@@ -149,21 +155,23 @@ pub async fn get_public_ip_stun_with_fallback_and_cache(
     cache: &Arc<RwLock<crate::public_ip::stun_cache::StunCache>>,
 ) -> Result<IpAddr, StunError> {
     let servers: Vec<String> = STUN_SERVERS.iter().map(|s| (*s).to_string()).collect();
-    get_public_ip_stun_with_servers_and_cache(&servers, timeout, cache).await
+    get_public_ip_stun_with_servers_and_cache(&servers, timeout, cache, 0).await
 }
 
 /// Get public IP using STUN, trying the provided servers in order (with injected cache)
 ///
 /// The first server is the primary; the remaining servers are fallbacks
 /// tried only if earlier ones fail. Server addresses are resolved through
-/// (and cached in) the provided cache on demand.
+/// (and cached in) the provided cache on demand. `verbose` levels 2+
+/// print per-server diagnostics to stderr.
 pub async fn get_public_ip_stun_with_servers_and_cache(
     servers: &[String],
     timeout: Duration,
     cache: &Arc<RwLock<crate::public_ip::stun_cache::StunCache>>,
+    verbose: u8,
 ) -> Result<IpAddr, StunError> {
     for server in servers {
-        match get_public_ip_stun_with_cache(server, timeout, cache).await {
+        match get_public_ip_stun_with_cache_and_verbose(server, timeout, cache, verbose).await {
             Ok(ip) => return Ok(ip),
             Err(_) => continue, // Try next server
         }

--- a/src/services.rs
+++ b/src/services.rs
@@ -115,10 +115,10 @@ impl Services {
         let stun = if let Some(cache) = stun_cache {
             StunClient::with_cache(
                 cache,
-                vec![
-                    "stun.l.google.com:19302".to_string(),
-                    "stun1.l.google.com:19302".to_string(),
-                ],
+                crate::public_ip::stun::STUN_SERVERS
+                    .iter()
+                    .map(|s| (*s).to_string())
+                    .collect(),
             )
         } else {
             StunClient::new()

--- a/src/socket/factory.rs
+++ b/src/socket/factory.rs
@@ -18,11 +18,30 @@ pub async fn create_probe_socket(
 }
 
 /// Create a probe socket with protocol and mode preferences
+///
+/// Equivalent to [`create_probe_socket_with_options_and_verbose`] with
+/// verbosity disabled.
 pub async fn create_probe_socket_with_options(
     target: IpAddr,
     timing_config: TimingConfig,
     protocol: Option<ProbeProtocol>,
     socket_mode: Option<SocketMode>,
+) -> Result<Box<dyn ProbeSocket>, TracerouteError> {
+    create_probe_socket_with_options_and_verbose(target, timing_config, protocol, socket_mode, 0)
+        .await
+}
+
+/// Create a probe socket with protocol and mode preferences and a verbosity level
+///
+/// `verbose` controls diagnostic output on stderr (0 = silent, 1+ = print
+/// the selected socket mode); it is threaded through explicitly rather than
+/// read from the environment so concurrent traces cannot affect each other.
+pub async fn create_probe_socket_with_options_and_verbose(
+    target: IpAddr,
+    timing_config: TimingConfig,
+    protocol: Option<ProbeProtocol>,
+    socket_mode: Option<SocketMode>,
+    verbose: u8,
 ) -> Result<Box<dyn ProbeSocket>, TracerouteError> {
     // Check for unsupported protocols
     if let Some(ProbeProtocol::Tcp) = protocol {
@@ -38,12 +57,9 @@ pub async fn create_probe_socket_with_options(
                 let _ = protocol;
                 let _ = socket_mode;
                 use super::windows::WindowsAsyncIcmpSocket;
-                let socket = WindowsAsyncIcmpSocket::new_with_config(timing_config)?;
+                let socket =
+                    WindowsAsyncIcmpSocket::new_with_config_and_verbose(timing_config, verbose)?;
 
-                let verbose = std::env::var("FTR_VERBOSE")
-                    .ok()
-                    .and_then(|v| v.parse::<u8>().ok())
-                    .unwrap_or(0);
                 if verbose > 0 {
                     eprintln!("Using Windows ICMP API mode for traceroute");
                 }
@@ -56,12 +72,9 @@ pub async fn create_probe_socket_with_options(
                 let _ = protocol;
                 let _ = socket_mode;
                 use super::macos::MacOSAsyncIcmpSocket;
-                let socket = MacOSAsyncIcmpSocket::new_with_config(timing_config)?;
+                let socket =
+                    MacOSAsyncIcmpSocket::new_with_config_and_verbose(timing_config, verbose)?;
 
-                let verbose = std::env::var("FTR_VERBOSE")
-                    .ok()
-                    .and_then(|v| v.parse::<u8>().ok())
-                    .unwrap_or(0);
                 if verbose > 0 {
                     eprintln!("Using DGRAM ICMP mode for traceroute (per-probe version)");
                 }
@@ -81,10 +94,6 @@ pub async fn create_probe_socket_with_options(
                             use super::linux::LinuxAsyncIcmpSocket;
                             let socket = LinuxAsyncIcmpSocket::new_with_config(timing_config)?;
 
-                            let verbose = std::env::var("FTR_VERBOSE")
-                                .ok()
-                                .and_then(|v| v.parse::<u8>().ok())
-                                .unwrap_or(0);
                             if verbose > 0 {
                                 eprintln!("Using Raw ICMP mode for traceroute");
                             }
@@ -105,10 +114,6 @@ pub async fn create_probe_socket_with_options(
                     use super::linux::LinuxAsyncUdpSocket;
                     let socket = LinuxAsyncUdpSocket::new_with_config(timing_config)?;
 
-                    let verbose = std::env::var("FTR_VERBOSE")
-                        .ok()
-                        .and_then(|v| v.parse::<u8>().ok())
-                        .unwrap_or(0);
                     if verbose > 0 {
                         eprintln!("Using UDP with IP_RECVERR (no root required)");
                     }
@@ -129,10 +134,6 @@ pub async fn create_probe_socket_with_options(
                 use super::bsd::BsdAsyncIcmpSocket;
                 let socket = BsdAsyncIcmpSocket::new_with_config(timing_config)?;
 
-                let verbose = std::env::var("FTR_VERBOSE")
-                    .ok()
-                    .and_then(|v| v.parse::<u8>().ok())
-                    .unwrap_or(0);
                 if verbose > 0 {
                     eprintln!("Using Raw ICMP mode for traceroute");
                 }
@@ -151,6 +152,7 @@ pub async fn create_probe_socket_with_options(
             )))]
             {
                 let _ = protocol;
+                let _ = verbose;
                 Err(TracerouteError::SocketError(
                     "Socket implementation not available for this platform".to_string(),
                 ))

--- a/src/socket/macos.rs
+++ b/src/socket/macos.rs
@@ -44,10 +44,15 @@ impl MacOSAsyncIcmpSocket {
 
     /// Create a new macOS async ICMP socket with timing configuration
     pub fn new_with_config(timing_config: TimingConfig) -> Result<Self, TracerouteError> {
-        let verbose = std::env::var("FTR_VERBOSE")
-            .ok()
-            .and_then(|v| v.parse::<u8>().ok())
-            .unwrap_or(0);
+        Self::new_with_config_and_verbose(timing_config, 0)
+    }
+
+    /// Create a new macOS async ICMP socket with timing configuration and
+    /// an explicit verbosity level (replaces the former FTR_VERBOSE lookup)
+    pub fn new_with_config_and_verbose(
+        timing_config: TimingConfig,
+        verbose: u8,
+    ) -> Result<Self, TracerouteError> {
         trace_time!(
             verbose,
             "Creating macOS async ICMP socket (per-probe version)"

--- a/src/socket/windows.rs
+++ b/src/socket/windows.rs
@@ -66,11 +66,21 @@ pub struct WindowsAsyncIcmpSocket {
     destination_reached: Arc<Mutex<bool>>,
     pending_count: Arc<Mutex<usize>>,
     timing_config: TimingConfig,
+    verbose: u8,
 }
 
 impl WindowsAsyncIcmpSocket {
     /// Create a new Windows async ICMP socket
     pub fn new_with_config(timing_config: TimingConfig) -> Result<Self, TracerouteError> {
+        Self::new_with_config_and_verbose(timing_config, 0)
+    }
+
+    /// Create a new Windows async ICMP socket with an explicit verbosity
+    /// level (replaces the former FTR_VERBOSE environment lookup)
+    pub fn new_with_config_and_verbose(
+        timing_config: TimingConfig,
+        verbose: u8,
+    ) -> Result<Self, TracerouteError> {
         let icmp_handle = unsafe { IcmpCreateFile() };
         if icmp_handle.is_null() {
             return Err(TracerouteError::SocketError(
@@ -83,6 +93,7 @@ impl WindowsAsyncIcmpSocket {
             destination_reached: Arc::new(Mutex::new(false)),
             pending_count: Arc::new(Mutex::new(0)),
             timing_config,
+            verbose,
         })
     }
 
@@ -334,12 +345,7 @@ impl ProbeSocket for WindowsAsyncIcmpSocket {
             let timeout_duration = self.timing_config.socket_read_timeout;
 
             // Debug logging for timeout analysis
-            let verbose = std::env::var("FTR_VERBOSE")
-                .ok()
-                .and_then(|v| v.parse::<u8>().ok())
-                .unwrap_or(0);
-
-            if verbose >= 3 {
+            if self.verbose >= 3 {
                 let windows_timeout_ms = {
                     let user_timeout_ms = self.timing_config.socket_read_timeout.as_millis() as u32;
                     let windows_timeout =

--- a/src/traceroute/api.rs
+++ b/src/traceroute/api.rs
@@ -99,7 +99,9 @@ impl Traceroute {
         )
         .await?;
 
-        // Create and run fully parallel async engine
+        // Create and run fully parallel async engine. Engine errors are
+        // already TracerouteError values; propagate them unchanged so typed
+        // variants (e.g. Ipv6NotSupported, InsufficientPermissions) survive.
         let engine = if let Some(services) = self.services {
             TracerouteEngine::new_with_services(
                 socket,
@@ -107,18 +109,12 @@ impl Traceroute {
                 self.target_ip,
                 std::sync::Arc::new(services),
             )
-            .await
-            .map_err(|e| TracerouteError::SocketError(e.to_string()))?
+            .await?
         } else {
-            TracerouteEngine::new(socket, self.config.clone(), self.target_ip)
-                .await
-                .map_err(|e| TracerouteError::SocketError(e.to_string()))?
+            TracerouteEngine::new(socket, self.config.clone(), self.target_ip).await?
         };
 
-        let result = engine
-            .run()
-            .await
-            .map_err(|e| TracerouteError::SocketError(e.to_string()))?;
+        let result = engine.run().await?;
 
         // The fully parallel engine handles enrichment internally, so we can just return
         Ok(result)

--- a/src/traceroute/api.rs
+++ b/src/traceroute/api.rs
@@ -5,7 +5,7 @@
 
 use crate::dns::resolver;
 use crate::services::Services;
-use crate::socket::factory::create_probe_socket_with_options;
+use crate::socket::factory::create_probe_socket_with_options_and_verbose;
 use crate::traceroute::engine::TracerouteEngine;
 use crate::traceroute::{TracerouteConfig, TracerouteError, TracerouteResult};
 use std::net::IpAddr;
@@ -87,17 +87,15 @@ impl Traceroute {
         let mut timing_config = self.config.timing.clone();
         timing_config.socket_read_timeout = self.config.probe_timeout;
 
-        // Set verbose flag in environment for socket to pick up
-        if self.config.verbose > 0 {
-            std::env::set_var("FTR_VERBOSE", self.config.verbose.to_string());
-        }
-
-        // Create socket with protocol preference
-        let socket = create_probe_socket_with_options(
+        // Create socket with protocol preference; verbosity is passed
+        // explicitly (never via environment variables, which would race
+        // between concurrent traces in the same process)
+        let socket = create_probe_socket_with_options_and_verbose(
             self.target_ip,
             timing_config,
             self.config.protocol,
             self.config.socket_mode,
+            self.config.verbose,
         )
         .await?;
 
@@ -293,7 +291,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_verbose_environment_setting() {
+    async fn test_verbose_config_does_not_touch_environment() {
         let config = TracerouteConfig::builder()
             .target("127.0.0.1")
             .verbose(2)
@@ -301,22 +299,15 @@ mod tests {
             .probe_timeout(Duration::from_millis(100))
             .build()
             .unwrap();
+        assert_eq!(config.verbose, 2);
 
         let traceroute = Traceroute::new(config).await.unwrap();
 
-        // Store original value
-        let original = std::env::var("FTR_VERBOSE").ok();
-
-        // This will set the environment variable (with timeout)
+        // Verbosity is threaded through explicitly; running a trace must not
+        // mutate process-global environment state (which would race between
+        // concurrent traces)
+        let before = std::env::var("FTR_VERBOSE").ok();
         let _ = tokio::time::timeout(Duration::from_secs(5), traceroute.run()).await;
-
-        // Check it was set
-        assert_eq!(std::env::var("FTR_VERBOSE").ok(), Some("2".to_string()));
-
-        // Restore original
-        match original {
-            Some(val) => std::env::set_var("FTR_VERBOSE", val),
-            None => std::env::remove_var("FTR_VERBOSE"),
-        }
+        assert_eq!(std::env::var("FTR_VERBOSE").ok(), before);
     }
 }

--- a/src/traceroute/engine.rs
+++ b/src/traceroute/engine.rs
@@ -53,9 +53,10 @@ impl TracerouteEngine {
         target: IpAddr,
         services: Arc<Services>,
     ) -> Result<Self, TracerouteError> {
-        // Create enrichment service upfront
+        // Create enrichment service upfront, backed by the injected services
+        // so per-hop enrichment shares their (possibly pre-warmed) caches
         let enrichment_service = Arc::new(
-            EnrichmentService::new()
+            EnrichmentService::new_with_services(Arc::clone(&services))
                 .await
                 .map_err(|e| TracerouteError::Other(e.to_string()))?,
         );

--- a/src/traceroute/engine_test.rs
+++ b/src/traceroute/engine_test.rs
@@ -281,3 +281,81 @@ async fn test_engine_overall_timeout() {
     // Should complete without error, but won't have all hops
     assert!(!result.destination_reached);
 }
+
+#[tokio::test]
+async fn test_engine_uses_injected_services_for_enrichment() {
+    use crate::asn::cache::AsnCache;
+    use crate::dns::cache::RdnsCache;
+    use crate::services::Services;
+    use crate::traceroute::AsnInfo;
+    use std::sync::Arc;
+
+    let dest = Ipv4Addr::new(8, 8, 8, 8);
+    let mut responses = HashMap::new();
+    responses.insert(1, (dest, true));
+    let socket = MockSocket::new(responses, Duration::from_millis(1));
+
+    // Pre-warm the injected services' caches with sentinel values. Cache hits
+    // are served before any network I/O, so all enrichment (per-hop ASN/rDNS,
+    // destination ASN, ISP detection from the provided public IP) resolves
+    // from the cache. If the engine ignored the injected services (the old
+    // bug), hop enrichment would perform live lookups and the sentinels would
+    // never appear.
+    let asn_cache = AsnCache::new();
+    asn_cache.insert(
+        "8.8.8.0/24".parse().expect("valid prefix"),
+        AsnInfo {
+            asn: 64512,
+            name: "SENTINEL-AS".to_string(),
+            prefix: "8.8.8.0/24".to_string(),
+            country_code: "ZZ".to_string(),
+            registry: "test".to_string(),
+        },
+    );
+    let rdns_cache = RdnsCache::with_default_ttl();
+    rdns_cache.insert(IpAddr::V4(dest), "sentinel.rdns.test".to_string());
+
+    let services = Arc::new(Services::with_caches(
+        Some(asn_cache),
+        Some(rdns_cache),
+        None,
+    ));
+
+    let config = TracerouteConfig::builder()
+        .target("8.8.8.8")
+        .max_hops(2)
+        .probe_timeout(Duration::from_millis(200))
+        .overall_timeout(Duration::from_secs(2))
+        .enable_asn_lookup(true)
+        .enable_rdns(true)
+        // Providing the public IP avoids STUN; its ASN/rDNS hit the cache too
+        .public_ip(IpAddr::V4(dest))
+        .build()
+        .expect("valid config");
+
+    let target: IpAddr = IpAddr::V4(dest);
+    let engine =
+        super::TracerouteEngine::new_with_services(Box::new(socket), config, target, services)
+            .await
+            .expect("engine creation");
+
+    let result = engine.run().await.expect("traceroute should succeed");
+
+    let hop = result
+        .hops
+        .iter()
+        .find(|h| h.addr == Some(target))
+        .expect("destination hop present");
+    let asn = hop
+        .asn_info
+        .as_ref()
+        .expect("hop ASN info should come from the injected cache");
+    assert_eq!(asn.asn, 64512);
+    assert_eq!(asn.name, "SENTINEL-AS");
+    assert_eq!(hop.hostname.as_deref(), Some("sentinel.rdns.test"));
+
+    // ISP info is resolved through the same injected services
+    let isp = result.isp_info.expect("ISP info present");
+    assert_eq!(isp.asn, 64512);
+    assert_eq!(isp.hostname.as_deref(), Some("sentinel.rdns.test"));
+}


### PR DESCRIPTION
Five correctness fixes from code review. Branch was based on `docs/accuracy-refresh` (#23), which has since merged, so the diff contains only these changes.

## 1. Enrichment now uses injected Services (HIGH)

**Before:** `TracerouteEngine::new_with_services` used the injected `Services` for ISP/destination-ASN lookups, but per-hop enrichment called `EnrichmentService::new()`, which built a fresh `Services`. Caches pre-warmed via `Ftr::with_caches` never reached hop enrichment; every trace ran two disjoint cache sets.

**After:** New `EnrichmentService::new_with_services(Arc<Services>)`; the engine threads its injected services into hop enrichment. Regression tests (enrichment-level and engine-level with the mock socket) pre-warm ASN/rDNS caches with sentinel values and assert they surface in hop results with zero network I/O. Verified the engine-level test fails on the old code.

## 2. StunClient custom servers honored (MEDIUM)

**Before:** `StunClient::with_servers`/`with_cache` stored the server list but `get_public_ip` iterated the hardcoded `STUN_SERVERS` const; custom servers were only used for cache prewarming.

**After:** New `get_public_ip_stun_with_servers_and_cache()` takes an explicit server list; `StunClient::get_public_ip()` queries its configured servers in order. `StunClient::new()` and `Services::with_caches` now default to the full `STUN_SERVERS` list (Google x2 + Cloudflare) — matching what the query path actually used before, so default runtime behavior is unchanged. Test asserts a client configured with only an unresolvable server fails instead of silently using defaults.

## 3. env::set_var intra-process signaling removed (HIGH)

**Before:** `Traceroute::run` did `env::set_var("FTR_VERBOSE", ...)` read back by the socket factory, macOS/Windows sockets, and the STUN path; `main.rs` did `env::set_var("FTR_STUN_SERVER", ...)` read back in `stun.rs`. This races between concurrent traces in one process, and `set_var` becomes `unsafe` in edition 2024.

**After:** All `set_var` calls and `FTR_VERBOSE`/`FTR_STUN_SERVER` reads removed. Verbosity flows as `u8` parameters: `Traceroute::run` -> `create_probe_socket_with_options_and_verbose` -> platform socket constructors (`new_with_config_and_verbose`); the Windows socket stores `verbose` instead of reading the environment per probe. The custom STUN server flows via `StunClient::with_servers` + new `Ftr::with_services`; the CLI builds its services from `--stun-server` (custom first, defaults as fallback — same behavior as before) and `-v` (`StunClient::with_verbose`). The `env::var("CI")` test gating in `linux.rs` is intentionally untouched. Public API kept additive: existing factory/STUN functions delegate with verbosity 0. The env-mutating test in `api.rs` is replaced by one asserting a trace leaves the environment unchanged.

Cross-checked with `cargo check` for `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-msvc` in addition to the host macOS build.

## 4. Engine errors propagated without re-wrapping (LOW-MEDIUM)

**Before:** `Traceroute::run` re-wrapped every engine error into `TracerouteError::SocketError(String)`, destroying typed variants (`Ipv6NotSupported`, `InsufficientPermissions`, ...) that callers are documented to match on.

**After:** Errors propagate unchanged with `?` — the engine already returns `TracerouteError`.

## 5. DNS resolver hardening (MEDIUM)

**Before:** the custom UDP DNS client parsed any datagram arriving on the socket (query ID effectively constant and unchecked, QR bit ignored), had no retransmission (one lost datagram = 5s timeout), used only 1.1.1.1, and ignored the TC bit (silently parsing truncated responses).

**After:**
- Random per-query ID (getrandom, clock fallback); receive loop discards datagrams with mismatched ID or QR clear until the deadline; socket is `connect()`ed so the OS drops datagrams from other sources.
- One retransmission halfway through the per-server timeout.
- 8.8.8.8 fallback after 1.1.1.1 fails; authoritative NXDOMAIN from the primary short-circuits (no pointless second query).
- TC bit yields a distinct `DnsError::Truncated` (TCP fallback documented as future work).
- Synthetic-buffer unit tests: mismatched ID rejected, query packet not accepted as response, short datagram rejected, TC bit detected.

Note: worst-case latency for a completely failed lookup grows from ~5s to ~10s (two servers x 5s); successful-but-lossy lookups get much faster thanks to the retransmit.

## Validation

- `cargo fmt -- --check`, `cargo clippy -- -D warnings`: clean
- `cargo test`: all 300+ tests pass locally (macOS), including live-network tests
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: clean
- `cargo check --target x86_64-unknown-linux-gnu` / `x86_64-pc-windows-msvc`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)