### PR TITLE
chore: Fix clippy lint debt in tests, enforce --all-targets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,9 @@ jobs:
       with:
         shared-key: "ci-ubuntu-latest"
     - name: Run clippy
-      run: cargo clippy -- -D warnings
+      # --all-targets also lints tests, benches, and examples so lint debt
+      # cannot re-accumulate outside the library/binary targets.
+      run: cargo clippy --all-targets -- -D warnings
 
   coverage:
     name: Code coverage

--- a/benches/traceroute_bench.rs
+++ b/benches/traceroute_bench.rs
@@ -1,9 +1,13 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+//! Criterion benchmarks for traceroute performance (localhost and remote,
+//! with and without ASN/rDNS enrichment).
+
+use criterion::{Criterion, criterion_main};
 use ftr::{TracerouteConfig, trace_with_config};
+use std::hint::black_box;
 use std::time::Duration;
 
 fn benchmark_traceroute_local(c: &mut Criterion) {
-    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let runtime = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
 
     c.bench_function("traceroute_localhost", |b| {
         b.iter(|| {
@@ -16,7 +20,7 @@ fn benchmark_traceroute_local(c: &mut Criterion) {
                     .enable_asn_lookup(false)
                     .enable_rdns(false)
                     .build()
-                    .unwrap();
+                    .expect("failed to build traceroute config");
 
                 let _ = trace_with_config(black_box(config)).await;
             })
@@ -25,7 +29,7 @@ fn benchmark_traceroute_local(c: &mut Criterion) {
 }
 
 fn benchmark_traceroute_with_enrichment(c: &mut Criterion) {
-    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let runtime = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
 
     c.bench_function("traceroute_8.8.8.8_enriched", |b| {
         b.iter(|| {
@@ -38,7 +42,7 @@ fn benchmark_traceroute_with_enrichment(c: &mut Criterion) {
                     .enable_asn_lookup(true)
                     .enable_rdns(true)
                     .build()
-                    .unwrap();
+                    .expect("failed to build traceroute config");
 
                 let _ = trace_with_config(black_box(config)).await;
             })
@@ -47,7 +51,7 @@ fn benchmark_traceroute_with_enrichment(c: &mut Criterion) {
 }
 
 fn benchmark_traceroute_no_enrichment(c: &mut Criterion) {
-    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let runtime = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
 
     c.bench_function("traceroute_8.8.8.8_raw", |b| {
         b.iter(|| {
@@ -60,7 +64,7 @@ fn benchmark_traceroute_no_enrichment(c: &mut Criterion) {
                     .enable_asn_lookup(false)
                     .enable_rdns(false)
                     .build()
-                    .unwrap();
+                    .expect("failed to build traceroute config");
 
                 let _ = trace_with_config(black_box(config)).await;
             })
@@ -68,10 +72,21 @@ fn benchmark_traceroute_no_enrichment(c: &mut Criterion) {
     });
 }
 
-criterion_group!(
-    benches,
-    benchmark_traceroute_local,
-    benchmark_traceroute_no_enrichment,
-    benchmark_traceroute_with_enrichment
-);
-criterion_main!(benches);
+// criterion_group! expands to an undocumented `pub fn`, which trips the
+// missing_docs lint. Housing it in a private module keeps the generated
+// function out of the crate's public surface so no doc (or allow) is needed.
+mod groups {
+    use super::{
+        benchmark_traceroute_local, benchmark_traceroute_no_enrichment,
+        benchmark_traceroute_with_enrichment,
+    };
+    use criterion::criterion_group;
+
+    criterion_group!(
+        benches,
+        benchmark_traceroute_local,
+        benchmark_traceroute_no_enrichment,
+        benchmark_traceroute_with_enrichment
+    );
+}
+criterion_main!(groups::benches);

--- a/tests/async_multi_hop.rs
+++ b/tests/async_multi_hop.rs
@@ -13,88 +13,82 @@ mod tests {
         let target = "8.8.8.8";
 
         let ftr_instance = Ftr::new();
-        match ftr_instance.trace(target).await {
-            Ok(result) => {
-                eprintln!("Async trace completed:");
-                eprintln!("  Protocol: {:?}", result.protocol_used);
-                eprintln!("  Socket mode: {:?}", result.socket_mode_used);
-                eprintln!("  Total hops: {}", result.hop_count());
-
-                // Count how many hops actually responded
-                let hops_with_responses: Vec<_> = result
-                    .hops
-                    .iter()
-                    .filter(|hop| hop.addr.is_some())
-                    .collect();
-
-                eprintln!("  Hops with responses: {}", hops_with_responses.len());
-
-                // Debug info if we got no responses
-                if hops_with_responses.is_empty() {
-                    eprintln!("\n=== DEBUG: Got 0 responses ===");
-                    eprintln!("Environment info:");
-                    eprintln!("  OS: {}", std::env::consts::OS);
-                    eprintln!("  CI: {:?}", std::env::var("CI"));
-                    eprintln!("  GITHUB_ACTIONS: {:?}", std::env::var("GITHUB_ACTIONS"));
-
-                    // GitHub Actions runners often have restricted ICMP
-                    // Windows runners are hosted in Azure which blocks inbound ICMP
-                    // Ubuntu runners also have unreliable ICMP responses
-                    // See: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
-                    if std::env::var("GITHUB_ACTIONS").is_ok() {
-                        let os = std::env::consts::OS;
-                        if os == "windows" || os == "linux" {
-                            eprintln!("\nNo ICMP responses on GitHub Actions {} runner", os);
-                            eprintln!(
-                                "This is expected - GitHub Actions runners have restricted ICMP."
-                            );
-                            eprintln!("Windows: Azure blocks inbound ICMP packets.");
-                            eprintln!(
-                                "Linux: Unreliable ICMP due to virtualization/network restrictions."
-                            );
-                            eprintln!("Skipping test on GitHub Actions {}.", os);
-                            return;
-                        }
-                    }
-
-                    eprintln!("\nUnexpected: No ICMP responses received");
-                    eprintln!("This could indicate:");
-                    eprintln!("  - Firewall blocking ICMP");
-                    eprintln!("  - Network configuration issues");
-                    eprintln!("  - Target unreachable");
-                }
-
-                // Verify we have responses from different addresses
-                let unique_addresses: std::collections::HashSet<_> =
-                    result.hops.iter().filter_map(|hop| hop.addr).collect();
-
-                // We should see at least 3 hops for internet destinations
-                assert!(
-                    result.hop_count() >= 3,
-                    "Expected at least 3 hops, got {}",
-                    result.hop_count()
-                );
-
-                // Verify we have responses from different addresses
-                // Note: On some systems (like macOS with certain network configs),
-                // we might see the same address (e.g., 127.0.0.1) for multiple hops
-                assert!(
-                    unique_addresses.len() >= 1,
-                    "Expected responses from at least 1 address, got {}",
-                    unique_addresses.len()
-                );
-            }
-            Err(e) => {
-                // If we get a permission error, skip the test
-                if e.to_string().contains("Permission denied")
-                    || e.to_string().contains("requires root")
-                {
-                    eprintln!("Skipping test due to permission error: {}", e);
-                    return;
-                }
-                panic!("Unexpected error: {}", e);
+        let result = ftr_instance.trace(target).await;
+        if let Err(e) = &result {
+            // If we get a permission error, skip the test
+            if e.to_string().contains("Permission denied")
+                || e.to_string().contains("requires root")
+            {
+                eprintln!("Skipping test due to permission error: {}", e);
+                return;
             }
         }
+        let result = result.expect("trace to 8.8.8.8 failed with unexpected error");
+
+        eprintln!("Async trace completed:");
+        eprintln!("  Protocol: {:?}", result.protocol_used);
+        eprintln!("  Socket mode: {:?}", result.socket_mode_used);
+        eprintln!("  Total hops: {}", result.hop_count());
+
+        // Count how many hops actually responded
+        let hops_with_responses: Vec<_> = result
+            .hops
+            .iter()
+            .filter(|hop| hop.addr.is_some())
+            .collect();
+
+        eprintln!("  Hops with responses: {}", hops_with_responses.len());
+
+        // Debug info if we got no responses
+        if hops_with_responses.is_empty() {
+            eprintln!("\n=== DEBUG: Got 0 responses ===");
+            eprintln!("Environment info:");
+            eprintln!("  OS: {}", std::env::consts::OS);
+            eprintln!("  CI: {:?}", std::env::var("CI"));
+            eprintln!("  GITHUB_ACTIONS: {:?}", std::env::var("GITHUB_ACTIONS"));
+
+            // GitHub Actions runners often have restricted ICMP
+            // Windows runners are hosted in Azure which blocks inbound ICMP
+            // Ubuntu runners also have unreliable ICMP responses
+            // See: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+            if std::env::var("GITHUB_ACTIONS").is_ok() {
+                let os = std::env::consts::OS;
+                if os == "windows" || os == "linux" {
+                    eprintln!("\nNo ICMP responses on GitHub Actions {} runner", os);
+                    eprintln!("This is expected - GitHub Actions runners have restricted ICMP.");
+                    eprintln!("Windows: Azure blocks inbound ICMP packets.");
+                    eprintln!("Linux: Unreliable ICMP due to virtualization/network restrictions.");
+                    eprintln!("Skipping test on GitHub Actions {}.", os);
+                    return;
+                }
+            }
+
+            eprintln!("\nUnexpected: No ICMP responses received");
+            eprintln!("This could indicate:");
+            eprintln!("  - Firewall blocking ICMP");
+            eprintln!("  - Network configuration issues");
+            eprintln!("  - Target unreachable");
+        }
+
+        // Verify we have responses from different addresses
+        let unique_addresses: std::collections::HashSet<_> =
+            result.hops.iter().filter_map(|hop| hop.addr).collect();
+
+        // We should see at least 3 hops for internet destinations
+        assert!(
+            result.hop_count() >= 3,
+            "Expected at least 3 hops, got {}",
+            result.hop_count()
+        );
+
+        // Verify we have responses from different addresses
+        // Note: On some systems (like macOS with certain network configs),
+        // we might see the same address (e.g., 127.0.0.1) for multiple hops
+        assert!(
+            !unique_addresses.is_empty(),
+            "Expected responses from at least 1 address, got {}",
+            unique_addresses.len()
+        );
     }
 
     #[tokio::test]
@@ -105,37 +99,34 @@ mod tests {
             .target("1.1.1.1")
             .protocol(ftr::ProbeProtocol::Icmp)
             .build()
-            .unwrap();
+            .expect("failed to build traceroute config");
 
         let ftr_instance = Ftr::new();
-        match ftr_instance.trace_with_config(config).await {
-            Ok(result) => {
-                // Should get multiple hops
-                assert!(
-                    result.hop_count() >= 3,
-                    "macOS async ICMP should show multiple hops, got {}",
-                    result.hop_count()
-                );
-
-                // Check we got actual responses
-                let hops_with_responses =
-                    result.hops.iter().filter(|hop| hop.addr.is_some()).count();
-
-                assert!(
-                    hops_with_responses >= 2,
-                    "macOS async ICMP should show responses from multiple hops, got {}",
-                    hops_with_responses
-                );
-            }
-            Err(e) => {
-                // Skip if permission denied
-                if e.to_string().contains("Permission denied") {
-                    eprintln!("Skipping macOS ICMP test due to permissions");
-                    return;
-                }
-                panic!("macOS async ICMP failed: {}", e);
+        let result = ftr_instance.trace_with_config(config).await;
+        if let Err(e) = &result {
+            // Skip if permission denied
+            if e.to_string().contains("Permission denied") {
+                eprintln!("Skipping macOS ICMP test due to permissions");
+                return;
             }
         }
+        let result = result.expect("macOS async ICMP trace failed");
+
+        // Should get multiple hops
+        assert!(
+            result.hop_count() >= 3,
+            "macOS async ICMP should show multiple hops, got {}",
+            result.hop_count()
+        );
+
+        // Check we got actual responses
+        let hops_with_responses = result.hops.iter().filter(|hop| hop.addr.is_some()).count();
+
+        assert!(
+            hops_with_responses >= 2,
+            "macOS async ICMP should show responses from multiple hops, got {}",
+            hops_with_responses
+        );
     }
 
     #[tokio::test]
@@ -145,50 +136,48 @@ mod tests {
         let target = "1.1.1.1"; // Cloudflare DNS - reliable and fast
 
         let ftr_instance = Ftr::new();
-        match ftr_instance.trace(target).await {
-            Ok(result) => {
-                // Should have multiple hops for an external target
-                assert!(
-                    result.hop_count() >= 2,
-                    "External target should have multiple hops, got {}",
-                    result.hop_count()
-                );
-
-                // Verify TTLs are in ascending order
-                let mut prev_ttl = 0;
-                for hop in &result.hops {
-                    assert!(
-                        hop.ttl > prev_ttl,
-                        "TTLs should be in ascending order: {} <= {}",
-                        hop.ttl,
-                        prev_ttl
-                    );
-                    prev_ttl = hop.ttl;
-                }
-
-                // Should not have huge gaps in TTL sequence (no more than 5 missing hops)
-                let ttls: Vec<u8> = result.hops.iter().map(|h| h.ttl).collect();
-                for window in ttls.windows(2) {
-                    assert!(
-                        window[1] - window[0] <= 5,
-                        "Large gap in TTL sequence: {} to {}",
-                        window[0],
-                        window[1]
-                    );
-                }
+        let result = ftr_instance.trace(target).await;
+        if let Err(e) = &result {
+            // Skip on permission error or network issues
+            if e.to_string().contains("Permission denied") {
+                eprintln!("Skipping external target test due to permissions");
+                return;
             }
-            Err(e) => {
-                // Skip on permission error or network issues
-                if e.to_string().contains("Permission denied") {
-                    eprintln!("Skipping external target test due to permissions");
-                    return;
-                }
-                if e.to_string().contains("timed out") || e.to_string().contains("unreachable") {
-                    eprintln!("Skipping external target test due to network issues");
-                    return;
-                }
-                panic!("External trace failed: {}", e);
+            if e.to_string().contains("timed out") || e.to_string().contains("unreachable") {
+                eprintln!("Skipping external target test due to network issues");
+                return;
             }
+        }
+        let result = result.expect("external trace failed");
+
+        // Should have multiple hops for an external target
+        assert!(
+            result.hop_count() >= 2,
+            "External target should have multiple hops, got {}",
+            result.hop_count()
+        );
+
+        // Verify TTLs are in ascending order
+        let mut prev_ttl = 0;
+        for hop in &result.hops {
+            assert!(
+                hop.ttl > prev_ttl,
+                "TTLs should be in ascending order: {} <= {}",
+                hop.ttl,
+                prev_ttl
+            );
+            prev_ttl = hop.ttl;
+        }
+
+        // Should not have huge gaps in TTL sequence (no more than 5 missing hops)
+        let ttls: Vec<u8> = result.hops.iter().map(|h| h.ttl).collect();
+        for window in ttls.windows(2) {
+            assert!(
+                window[1] - window[0] <= 5,
+                "Large gap in TTL sequence: {} to {}",
+                window[0],
+                window[1]
+            );
         }
     }
 }

--- a/tests/cache_performance_test.rs
+++ b/tests/cache_performance_test.rs
@@ -20,7 +20,7 @@ async fn test_cache_improves_performance() {
         .enable_asn_lookup(true)
         .enable_rdns(true)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     // First trace - cold cache
     let start1 = Instant::now();
@@ -66,7 +66,7 @@ async fn test_multiple_targets_share_cache_benefits() {
         .enable_asn_lookup(true)
         .enable_rdns(true)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let _ = ftr.trace_with_config(config1).await;
 
@@ -77,7 +77,7 @@ async fn test_multiple_targets_share_cache_benefits() {
         .enable_asn_lookup(true)
         .enable_rdns(true)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let start = Instant::now();
     let result2 = ftr.trace_with_config(config2).await;
@@ -109,7 +109,7 @@ async fn test_cache_isolation_performance() {
         .enable_asn_lookup(true)
         .enable_rdns(true)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     // Warm up ftr1's cache
     let _ = ftr1.trace_with_config(config.clone()).await;

--- a/tests/caching_verification_test.rs
+++ b/tests/caching_verification_test.rs
@@ -26,7 +26,7 @@ async fn test_traceroute_with_caching() {
         .enable_asn_lookup(true)
         .enable_rdns(true)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let result1 = ftr_instance.trace_with_config(config1).await;
     match result1 {
@@ -62,7 +62,7 @@ async fn test_traceroute_with_caching() {
                 .enable_asn_lookup(true)
                 .enable_rdns(true)
                 .build()
-                .unwrap();
+                .expect("failed to build traceroute config");
 
             let result2 = ftr_instance.trace_with_config(config2).await;
             match result2 {
@@ -136,7 +136,7 @@ async fn test_multiple_targets_share_cache() {
             .enable_asn_lookup(true)
             .enable_rdns(true)
             .build()
-            .unwrap();
+            .expect("failed to build traceroute config");
 
         match ftr_instance.trace_with_config(config).await {
             Ok(trace_result) => {

--- a/tests/ci_filter_test.rs
+++ b/tests/ci_filter_test.rs
@@ -13,8 +13,8 @@ fn test_with_2_in_name() {
 
 #[test]
 fn test_without_number() {
-    // This test has no "2" in the name
-    assert!(true);
+    // This test has no "2" in the name. Its body is intentionally trivial:
+    // what matters is that the test runs at all (see module docs above).
 }
 
 #[test]

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1,7 +1,5 @@
 //! Integration tests for ftr CLI functionality
 
-#![allow(clippy::unwrap_used)]
-
 use assert_cmd::Command;
 use predicates::prelude::*;
 use serde_json::Value;

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -1,14 +1,12 @@
 //! Integration tests for edge cases and performance
 
-#![allow(clippy::unwrap_used)]
-
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::time::{Duration, Instant};
 
 #[test]
 fn test_very_low_timeout() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args([
         "--probe-timeout-ms",
         "1",
@@ -20,7 +18,7 @@ fn test_very_low_timeout() {
     ]);
 
     let start = Instant::now();
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
     let duration = start.elapsed();
 
     // Should complete within reasonable time even with low timeout
@@ -40,7 +38,7 @@ fn test_very_low_timeout() {
 
 #[test]
 fn test_high_ttl_value() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args([
         "--start-ttl",
         "64",
@@ -50,7 +48,7 @@ fn test_high_ttl_value() {
         "127.0.0.1",
     ]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     // Should handle high TTL values appropriately
     if output.status.success() {
@@ -67,7 +65,7 @@ fn test_multiple_concurrent_instances() {
 
     for i in 0..3 {
         let handle = std::thread::spawn(move || {
-            let mut cmd = Command::cargo_bin("ftr").unwrap();
+            let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
             cmd.args([
                 "--start-ttl",
                 "1",
@@ -91,7 +89,7 @@ fn test_multiple_concurrent_instances() {
 
 #[test]
 fn test_ipv4_address_input() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args([
         "--start-ttl",
         "1",
@@ -101,7 +99,7 @@ fn test_ipv4_address_input() {
         "192.168.1.1",
     ]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     // Should accept IPv4 addresses directly
     if output.status.success() {
@@ -120,7 +118,7 @@ fn test_queries_edge_cases() {
     ];
 
     for (queries, should_succeed) in test_cases {
-        let mut cmd = Command::cargo_bin("ftr").unwrap();
+        let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
         cmd.args([
             "--queries",
             queries,
@@ -131,7 +129,7 @@ fn test_queries_edge_cases() {
             "127.0.0.1",
         ]);
 
-        let output = cmd.output().unwrap();
+        let output = cmd.output().expect("failed to run ftr");
 
         if should_succeed {
             // Should either succeed or fail with permission error, not parameter error
@@ -157,7 +155,7 @@ fn test_port_boundaries() {
     ];
 
     for (port, _should_succeed) in test_cases {
-        let mut cmd = Command::cargo_bin("ftr").unwrap();
+        let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
         cmd.args([
             "--protocol",
             "udp",
@@ -177,7 +175,7 @@ fn test_port_boundaries() {
 
 #[test]
 fn test_silent_hops_minimalist_output() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     // Use a high starting TTL to likely get some silent hops
     cmd.args([
         "--start-ttl",
@@ -188,7 +186,7 @@ fn test_silent_hops_minimalist_output() {
         "8.8.8.8",
     ]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);

--- a/tests/error_handling_test.rs
+++ b/tests/error_handling_test.rs
@@ -18,30 +18,29 @@ async fn test_insufficient_permissions_error() {
             .target("127.0.0.1")
             .socket_mode(SocketMode::Raw)
             .build()
-            .unwrap();
+            .expect("failed to build traceroute config");
 
         if !ftr::socket::utils::is_root() {
             let ftr_instance = ftr::Ftr::new();
             let result = ftr_instance.trace_with_config(config).await;
 
-            match result {
-                Err(TracerouteError::InsufficientPermissions {
-                    required,
-                    suggestion,
-                }) => {
-                    // Good! We got a structured error
-                    assert!(required.contains("root") || required.contains("CAP_NET_RAW"));
-                    assert!(!suggestion.is_empty());
-                    println!("Got expected structured error:");
-                    println!("  Required: {}", required);
-                    println!("  Suggestion: {}", suggestion);
-                }
-                Err(e) => {
-                    panic!("Expected InsufficientPermissions error, got: {:?}", e);
-                }
-                Ok(_) => {
-                    panic!("Expected permission error but operation succeeded");
-                }
+            let err = result.expect_err("Expected permission error but operation succeeded");
+            assert!(
+                matches!(err, TracerouteError::InsufficientPermissions { .. }),
+                "Expected InsufficientPermissions error, got: {:?}",
+                err
+            );
+            if let TracerouteError::InsufficientPermissions {
+                required,
+                suggestion,
+            } = err
+            {
+                // Good! We got a structured error
+                assert!(required.contains("root") || required.contains("CAP_NET_RAW"));
+                assert!(!suggestion.is_empty());
+                println!("Got expected structured error:");
+                println!("  Required: {}", required);
+                println!("  Suggestion: {}", suggestion);
             }
         }
     }
@@ -59,24 +58,18 @@ async fn test_tcp_not_implemented_error() {
         .target("127.0.0.1")
         .protocol(ProbeProtocol::Tcp)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let ftr_instance = ftr::Ftr::new();
     let result = ftr_instance.trace_with_config(config).await;
 
-    match result {
-        Err(TracerouteError::NotImplemented { feature }) => {
-            // Good! We got a structured error
-            assert_eq!(feature, "TCP traceroute");
-            println!("Got expected NotImplemented error for: {}", feature);
-        }
-        Err(e) => {
-            panic!("Expected NotImplemented error, got: {:?}", e);
-        }
-        Ok(_) => {
-            panic!("Expected NotImplemented error but operation succeeded");
-        }
-    }
+    let err = result.expect_err("Expected NotImplemented error but operation succeeded");
+    assert!(
+        matches!(&err, TracerouteError::NotImplemented { feature } if feature == "TCP traceroute"),
+        "Expected NotImplemented error for TCP traceroute, got: {:?}",
+        err
+    );
+    println!("Got expected NotImplemented error for TCP traceroute");
 }
 
 #[tokio::test]
@@ -84,23 +77,17 @@ async fn test_ipv6_not_supported_error() {
     let config = TracerouteConfigBuilder::new()
         .target("::1") // IPv6 localhost
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let ftr_instance = ftr::Ftr::new();
     let result = ftr_instance.trace_with_config(config).await;
 
-    match result {
-        Err(TracerouteError::Ipv6NotSupported) => {
-            // Good! We got a structured error
-            println!("Got expected Ipv6NotSupported error");
-        }
-        Err(e) => {
-            panic!("Expected Ipv6NotSupported error, got: {:?}", e);
-        }
-        Ok(_) => {
-            panic!("Expected Ipv6NotSupported error but operation succeeded");
-        }
-    }
+    assert!(
+        matches!(&result, Err(TracerouteError::Ipv6NotSupported)),
+        "Expected Ipv6NotSupported error, got: {:?}",
+        result
+    );
+    println!("Got expected Ipv6NotSupported error");
 }
 
 #[tokio::test]
@@ -108,24 +95,22 @@ async fn test_resolution_error() {
     let config = TracerouteConfigBuilder::new()
         .target("this-is-definitely-not-a-valid-hostname-12345.invalid")
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let ftr_instance = ftr::Ftr::new();
     let result = ftr_instance.trace_with_config(config).await;
 
-    match result {
-        Err(TracerouteError::ResolutionError(msg)) => {
+    let err = result.expect_err("Expected resolution error but operation succeeded");
+    match err {
+        TracerouteError::ResolutionError(msg) => {
             // Good! We got a structured error
             println!("Got expected ResolutionError: {}", msg);
             // Just check that we got a non-empty error message
             assert!(!msg.is_empty());
         }
-        Err(e) => {
+        e => {
             // Could also be a socket error if DNS resolution somehow succeeded
             println!("Got different error (might be OK): {:?}", e);
-        }
-        Ok(_) => {
-            panic!("Expected resolution error but operation succeeded");
         }
     }
 }
@@ -139,7 +124,11 @@ async fn test_config_validation_errors() {
         .build();
 
     assert!(result.is_err());
-    assert!(result.unwrap_err().contains("start_ttl must be at least 1"));
+    assert!(
+        result
+            .expect_err("start_ttl of 0 should fail validation")
+            .contains("start_ttl must be at least 1")
+    );
 
     // Test max_hops < start_ttl
     let result = TracerouteConfigBuilder::new()
@@ -151,7 +140,7 @@ async fn test_config_validation_errors() {
     assert!(result.is_err());
     assert!(
         result
-            .unwrap_err()
+            .expect_err("max_hops < start_ttl should fail validation")
             .contains("max_hops must be greater than or equal to start_ttl")
     );
 
@@ -162,20 +151,15 @@ async fn test_config_validation_errors() {
 
     // When passed through trace_with_config, should become TracerouteError::ConfigError
     let config = TracerouteConfigBuilder::new().target("").build();
+    assert!(config.is_err(), "Expected config validation to fail");
 
-    match config {
-        Err(_msg) => {
-            let ftr_instance = ftr::Ftr::new();
-            let result = ftr_instance.trace(&"").await;
-            match result {
-                Err(TracerouteError::ConfigError(e)) => {
-                    println!("Got expected ConfigError: {}", e);
-                }
-                _ => panic!("Expected ConfigError"),
-            }
-        }
-        Ok(_) => panic!("Expected config validation to fail"),
-    }
+    let ftr_instance = ftr::Ftr::new();
+    let result = ftr_instance.trace("").await;
+    assert!(
+        matches!(&result, Err(TracerouteError::ConfigError(_))),
+        "Expected ConfigError, got: {:?}",
+        result
+    );
 }
 
 #[tokio::test]

--- a/tests/event_overhead_test.rs
+++ b/tests/event_overhead_test.rs
@@ -11,7 +11,7 @@ async fn test_event_channel_overhead() {
     // Spawn a task to consume messages concurrently
     let consumer = tokio::spawn(async move {
         let mut count = 0;
-        while let Some(_) = rx.recv().await {
+        while rx.recv().await.is_some() {
             count += 1;
         }
         count
@@ -20,12 +20,12 @@ async fn test_event_channel_overhead() {
     // Measure channel send latency
     let start = Instant::now();
     for i in 0..1000 {
-        tx.send(i).await.unwrap();
+        tx.send(i).await.expect("channel send should succeed");
     }
     drop(tx); // Close the channel to signal completion
 
     // Wait for consumer to finish
-    let count = consumer.await.unwrap();
+    let count = consumer.await.expect("consumer task should not panic");
     let elapsed = start.elapsed();
 
     println!("Channel operations (1000 messages): {:?}", elapsed);

--- a/tests/freebsd_integration.rs
+++ b/tests/freebsd_integration.rs
@@ -8,10 +8,10 @@ use predicates::prelude::*;
 #[test]
 fn test_freebsd_requires_root() {
     // On FreeBSD, non-root execution should fail with clear error
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["--max-hops", "1", "127.0.0.1"]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     if !is_running_as_root() {
         // Non-root should fail with specific error
@@ -41,7 +41,7 @@ fn test_freebsd_requires_root() {
 #[test]
 fn test_freebsd_no_dgram_icmp() {
     // FreeBSD does not support DGRAM ICMP
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args([
         "--socket-mode",
         "dgram",
@@ -52,7 +52,7 @@ fn test_freebsd_no_dgram_icmp() {
         "127.0.0.1",
     ]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     if !is_running_as_root() {
         // Non-root: should get the root privilege error first
@@ -77,7 +77,7 @@ fn test_freebsd_raw_icmp_with_root() {
         return;
     }
 
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["-v", "--socket-mode", "raw", "--max-hops", "1", "127.0.0.1"]);
 
     cmd.assert()
@@ -92,7 +92,7 @@ fn test_freebsd_localhost_trace_with_root() {
         return;
     }
 
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["--max-hops", "1", "--no-enrich", "127.0.0.1"]);
 
     cmd.assert()
@@ -105,10 +105,10 @@ fn test_freebsd_localhost_trace_with_root() {
 fn test_freebsd_ca_cert_warning() {
     // Test that we get a warning about ca_root_nss if HTTPS fails
     // This test doesn't require root
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["--max-hops", "1", "8.8.8.8"]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     // If ca_root_nss is not installed, we should see the warning
@@ -124,10 +124,10 @@ fn test_freebsd_ca_cert_warning() {
 
 #[test]
 fn test_freebsd_udp_mode() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["--protocol", "udp", "--max-hops", "1", "127.0.0.1"]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     if !is_running_as_root() {
         // Non-root: should get root privilege error
@@ -148,10 +148,10 @@ fn test_freebsd_udp_mode() {
 #[test]
 fn test_freebsd_tcp_mode() {
     // TCP mode is not yet implemented
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["--protocol", "tcp", "--max-hops", "1", "127.0.0.1"]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     // Should fail with invalid value error since TCP is not implemented yet
     assert!(!output.status.success());
@@ -170,10 +170,10 @@ fn test_freebsd_json_output_with_root() {
         return;
     }
 
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["--json", "--max-hops", "1", "127.0.0.1"]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
     assert!(output.status.success());
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -194,7 +194,7 @@ fn test_freebsd_setuid_suggestion() {
         return;
     }
 
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["127.0.0.1"]);
 
     cmd.assert()

--- a/tests/freebsd_smoke.rs
+++ b/tests/freebsd_smoke.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 fn test_freebsd_binary_runs() {
     // Basic smoke test - binary should at least show help
     let output = Command::new("cargo")
-        .args(&["run", "--", "--help"])
+        .args(["run", "--", "--help"])
         .output()
         .expect("Failed to execute command");
 
@@ -20,7 +20,7 @@ fn test_freebsd_binary_runs() {
 #[test]
 fn test_freebsd_version() {
     let output = Command::new("cargo")
-        .args(&["run", "--", "--version"])
+        .args(["run", "--", "--version"])
         .output()
         .expect("Failed to execute command");
 
@@ -37,7 +37,7 @@ fn test_freebsd_non_root_error() {
     }
 
     let output = Command::new("cargo")
-        .args(&["run", "--", "127.0.0.1"])
+        .args(["run", "--", "127.0.0.1"])
         .output()
         .expect("Failed to execute command");
 
@@ -61,7 +61,7 @@ fn test_freebsd_with_sudo() {
     }
 
     let output = Command::new("cargo")
-        .args(&["run", "--", "--max-hops", "1", "127.0.0.1"])
+        .args(["run", "--", "--max-hops", "1", "127.0.0.1"])
         .output()
         .expect("Failed to execute command");
 
@@ -74,7 +74,7 @@ fn test_freebsd_with_sudo() {
 fn test_freebsd_ca_certs_check() {
     // Check if ca_root_nss is installed by trying to resolve DNS
     let output = Command::new("cargo")
-        .args(&["run", "--", "--max-hops", "1", "google.com"])
+        .args(["run", "--", "--max-hops", "1", "google.com"])
         .output()
         .expect("Failed to execute command");
 
@@ -93,7 +93,7 @@ fn test_freebsd_ca_certs_check() {
 fn test_freebsd_socket_compatibility() {
     // Test that asking for DGRAM ICMP explicitly fails with correct error
     let output = Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--",
             "--socket-mode",

--- a/tests/handle_pattern_api_test.rs
+++ b/tests/handle_pattern_api_test.rs
@@ -15,7 +15,7 @@ async fn test_ftr_instance_methods() {
         .target("::1")
         .max_hops(1)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let result = ftr.trace_with_config(config).await;
     assert!(result.is_ok() || result.is_err()); // Platform-dependent
@@ -113,7 +113,7 @@ async fn test_timing_config_flows_through() {
         .max_hops(1)
         .timing(custom_timing)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     // This should use the custom timing config
     let result = ftr.trace_with_config(config).await;
@@ -142,7 +142,7 @@ async fn test_ftr_default_is_same_as_new() {
         .target("localhost")
         .max_hops(1)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let (r1, r2) = tokio::join!(
         ftr1.trace_with_config(config.clone()),

--- a/tests/handle_pattern_test.rs
+++ b/tests/handle_pattern_test.rs
@@ -20,7 +20,7 @@ async fn test_ftr_instance_basic_trace() {
     let result = ftr.trace("127.0.0.1").await;
 
     assert!(result.is_ok(), "Failed to trace localhost: {:?}", result);
-    let trace_result = result.unwrap();
+    let trace_result = result.expect("trace to localhost should succeed");
     assert!(
         !trace_result.hops.is_empty(),
         "Should have at least one hop"
@@ -49,7 +49,7 @@ async fn test_ftr_instance_with_config() {
     let result = ftr.trace_with_config(config).await;
 
     assert!(result.is_ok(), "Failed to trace with config: {:?}", result);
-    let trace_result = result.unwrap();
+    let trace_result = result.expect("trace with config should succeed");
     assert!(
         !trace_result.hops.is_empty(),
         "Should have at least one hop"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -44,7 +44,7 @@ async fn test_trace_with_custom_config() {
         .enable_asn_lookup(false)
         .enable_rdns(false)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let result = trace_with_config(config).await;
 
@@ -72,7 +72,11 @@ async fn test_config_validation() {
     // Empty target
     let result = TracerouteConfigBuilder::new().build();
     assert!(result.is_err());
-    assert!(result.unwrap_err().contains("Target must be specified"));
+    assert!(
+        result
+            .expect_err("building config without a target should fail")
+            .contains("Target must be specified")
+    );
 
     // Invalid TTL values
     let result = TracerouteConfigBuilder::new()
@@ -101,7 +105,7 @@ async fn test_trace_with_ip_and_hostname() {
         .target_ip(ip)
         .max_hops(3)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let result = trace_with_config(config).await;
 
@@ -122,7 +126,7 @@ async fn test_hop_classification() {
         .max_hops(10)
         .enable_asn_lookup(true)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     match trace_with_config(config).await {
         Ok(trace_result) => {
@@ -219,7 +223,7 @@ async fn test_result_methods() {
     // Test destination_hop
     let dest_hop = result.destination_hop();
     assert!(dest_hop.is_some());
-    assert_eq!(dest_hop.unwrap().ttl, 3);
+    assert_eq!(dest_hop.expect("destination hop should exist").ttl, 3);
 
     // Test has_response_at_ttl
     assert!(result.has_response_at_ttl(1));
@@ -243,7 +247,7 @@ async fn test_result_methods() {
     // Test average_rtt_ms
     let avg_rtt = result.average_rtt_ms();
     assert!(avg_rtt.is_some());
-    assert_eq!(avg_rtt.unwrap(), 10.0); // (5 + 15) / 2, hop 3 has no RTT
+    assert_eq!(avg_rtt.expect("average RTT should be present"), 10.0); // (5 + 15) / 2, hop 3 has no RTT
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -252,12 +256,14 @@ async fn test_error_types() {
 
     // Invalid target (empty) - should get ConfigError
     let result = trace("").await;
-    match result {
-        Err(TracerouteError::ConfigError(msg)) => {
-            println!("Got expected ConfigError: {}", msg);
-            assert!(msg.contains("Target") || msg.contains("target"));
-        }
-        _ => panic!("Expected ConfigError for empty target"),
+    assert!(
+        matches!(&result, Err(TracerouteError::ConfigError(_))),
+        "Expected ConfigError for empty target, got: {:?}",
+        result
+    );
+    if let Err(TracerouteError::ConfigError(msg)) = &result {
+        println!("Got expected ConfigError: {}", msg);
+        assert!(msg.contains("Target") || msg.contains("target"));
     }
 
     // Test unimplemented TCP protocol
@@ -265,30 +271,31 @@ async fn test_error_types() {
         .target("127.0.0.1")
         .protocol(ProbeProtocol::Tcp)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let result = trace_with_config(config).await;
-    match result {
-        Err(TracerouteError::NotImplemented { feature }) => {
-            assert_eq!(feature, "TCP traceroute");
-        }
-        _ => panic!("Expected NotImplemented error for TCP"),
-    }
+    assert!(
+        matches!(
+            &result,
+            Err(TracerouteError::NotImplemented { feature }) if feature == "TCP traceroute"
+        ),
+        "Expected NotImplemented error for TCP, got: {:?}",
+        result
+    );
 
     // Test IPv6 not supported
     let result = trace("::1").await;
-    match result {
-        Err(TracerouteError::Ipv6NotSupported) => {
-            println!("Got expected Ipv6NotSupported error");
-        }
-        _ => panic!("Expected Ipv6NotSupported error"),
-    }
+    assert!(
+        matches!(&result, Err(TracerouteError::Ipv6NotSupported)),
+        "Expected Ipv6NotSupported error, got: {:?}",
+        result
+    );
 
     // Test resolution error
     let config = TracerouteConfigBuilder::new()
         .target("invalid.host.that.does.not.exist.example")
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let result = trace_with_config(config).await;
     match result {
@@ -316,7 +323,7 @@ async fn test_caching_behavior() {
         .enable_asn_lookup(true)
         .enable_rdns(true)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let config2 = TracerouteConfigBuilder::new()
         .target("127.0.0.1")
@@ -324,7 +331,7 @@ async fn test_caching_behavior() {
         .enable_asn_lookup(true)
         .enable_rdns(true)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     // Clear caches before test
     // Cache clearing removed - each Ftr instance has its own caches
@@ -354,7 +361,7 @@ async fn test_public_ip_parameter() {
         .public_ip(public_ip)
         .enable_asn_lookup(true)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     match trace_with_config(config).await {
         Ok(result) => {
@@ -380,7 +387,7 @@ async fn test_different_protocols() {
             .protocol(protocol)
             .max_hops(3)
             .build()
-            .unwrap();
+            .expect("failed to build traceroute config");
 
         let _ = trace_with_config(config).await;
         // We don't assert on results as different protocols have different permission requirements

--- a/tests/linux_async_udp_debug.rs
+++ b/tests/linux_async_udp_debug.rs
@@ -33,7 +33,9 @@ mod tests {
                 eprintln!("  ✓ Set TTL to 1");
 
                 // Try to send a packet to 8.8.8.8
-                let dest = "8.8.8.8:33434".parse::<std::net::SocketAddr>().unwrap();
+                let dest = "8.8.8.8:33434"
+                    .parse::<std::net::SocketAddr>()
+                    .expect("valid socket address");
                 match socket.send_to(b"test", dest) {
                     Ok(n) => eprintln!("  ✓ Sent {} bytes to {}", n, dest),
                     Err(e) => eprintln!("  ✗ Failed to send: {}", e),
@@ -58,7 +60,7 @@ mod tests {
             Ok(socket) => {
                 eprintln!("  ✓ Created LinuxAsyncUdpSocket");
 
-                let dest: IpAddr = "8.8.8.8".parse().unwrap();
+                let dest: IpAddr = "8.8.8.8".parse().expect("valid IP address");
                 let probe = ProbeInfo {
                     ttl: 1,
                     sequence: 1,

--- a/tests/parallel_isolation_test.rs
+++ b/tests/parallel_isolation_test.rs
@@ -18,7 +18,7 @@ async fn test_parallel_ftr_instances() {
                 .enable_asn_lookup(true)
                 .enable_rdns(true)
                 .build()
-                .unwrap();
+                .expect("failed to build traceroute config");
 
             let result = ftr.trace_with_config(config).await;
             (i, result.is_ok())
@@ -63,7 +63,7 @@ async fn test_cache_isolation_between_instances() {
                 .enable_asn_lookup(true)
                 .enable_rdns(true)
                 .build()
-                .unwrap();
+                .expect("failed to build traceroute config");
             ftr1_clone.trace_with_config(config).await
         },
         async move {
@@ -73,7 +73,7 @@ async fn test_cache_isolation_between_instances() {
                 .enable_asn_lookup(true)
                 .enable_rdns(true)
                 .build()
-                .unwrap();
+                .expect("failed to build traceroute config");
             ftr2_clone.trace_with_config(config).await
         }
     );
@@ -112,7 +112,7 @@ async fn test_high_concurrency_no_interference() {
                 .enable_asn_lookup(false) // Disable to speed up test
                 .enable_rdns(false) // Disable to speed up test
                 .build()
-                .unwrap();
+                .expect("failed to build traceroute config");
 
             let result = ftr_clone.trace_with_config(config).await;
             result.is_ok()
@@ -154,14 +154,14 @@ async fn test_separate_instances_separate_caches() {
         .max_hops(1)
         .enable_asn_lookup(true)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let config2 = TracerouteConfigBuilder::new()
         .target("10.0.0.1") // Different private IP
         .max_hops(1)
         .enable_asn_lookup(true)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     // Run traces on both instances
     let result1 = ftr1.trace_with_config(config1.clone()).await;
@@ -208,7 +208,7 @@ async fn test_stress_test_cache_isolation() {
                     .target(target)
                     .max_hops(1)
                     .build()
-                    .unwrap();
+                    .expect("failed to build traceroute config");
 
                 ftr_clone.trace_with_config(config).await.is_ok()
             });

--- a/tests/performance_test.rs
+++ b/tests/performance_test.rs
@@ -15,7 +15,7 @@ async fn test_traceroute_performance_localhost() {
         .enable_asn_lookup(false)
         .enable_rdns(false)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let result = trace_with_config(config).await;
     let elapsed = start.elapsed();
@@ -50,7 +50,7 @@ async fn test_traceroute_performance_remote() {
         .enable_asn_lookup(false)
         .enable_rdns(false)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
     let result = trace_with_config(config).await;
     let elapsed = start.elapsed();
@@ -101,7 +101,7 @@ async fn test_event_driven_efficiency() {
                 .enable_asn_lookup(false)
                 .enable_rdns(false)
                 .build()
-                .unwrap();
+                .expect("failed to build traceroute config");
 
             trace_with_config(config).await
         });

--- a/tests/service_api_integration_test.rs
+++ b/tests/service_api_integration_test.rs
@@ -8,7 +8,7 @@ async fn test_ftr_convenience_methods() {
     let ftr = Ftr::new();
 
     // Test ASN lookup with a public IP
-    let ip: IpAddr = "8.8.8.8".parse().unwrap();
+    let ip: IpAddr = "8.8.8.8".parse().expect("valid IP address");
     let result = ftr.lookup_asn(ip).await;
 
     // Only skip in CI environments where network may be unreliable
@@ -21,7 +21,7 @@ async fn test_ftr_convenience_methods() {
     }
 
     assert!(result.is_ok(), "ASN lookup failed: {:?}", result.err());
-    let asn_info = result.unwrap();
+    let asn_info = result.expect("ASN lookup should succeed");
 
     // Print actual values for debugging CI issues
     eprintln!("DEBUG: ASN lookup for 8.8.8.8 returned:");
@@ -45,7 +45,7 @@ async fn test_ftr_convenience_methods() {
     );
 
     // Test reverse DNS lookup
-    let dns_ip: IpAddr = "8.8.8.8".parse().unwrap();
+    let dns_ip: IpAddr = "8.8.8.8".parse().expect("valid IP address");
     let result = ftr.lookup_rdns(dns_ip).await;
     if let Ok(hostname) = result {
         assert!(hostname.contains("dns.google") || hostname.contains("google"));
@@ -60,7 +60,7 @@ async fn test_service_isolation() {
     let ftr2 = Ftr::new();
 
     // Perform lookups on both
-    let ip: IpAddr = "1.1.1.1".parse().unwrap();
+    let ip: IpAddr = "1.1.1.1".parse().expect("valid IP address");
 
     let result1 = ftr1.lookup_asn(ip).await;
     let result2 = ftr2.lookup_asn(ip).await;
@@ -76,7 +76,10 @@ async fn test_service_isolation() {
     assert!(result2.is_ok(), "Second lookup failed: {:?}", result2.err());
 
     // Results should be the same (same IP = same ASN)
-    assert_eq!(result1.unwrap().asn, result2.unwrap().asn);
+    assert_eq!(
+        result1.expect("first lookup should succeed").asn,
+        result2.expect("second lookup should succeed").asn
+    );
 }
 
 #[tokio::test]
@@ -84,7 +87,7 @@ async fn test_cache_clearing() {
     let ftr = Ftr::new();
 
     // Perform a lookup to populate caches
-    let ip: IpAddr = "8.8.4.4".parse().unwrap();
+    let ip: IpAddr = "8.8.4.4".parse().expect("valid IP address");
     let first_result = ftr.lookup_asn(ip).await;
 
     // Only skip in CI environments where network may be unreliable
@@ -119,7 +122,7 @@ async fn test_direct_service_access() {
     // Access ASN service directly (no locking needed)
     let asn_service = &ftr.services.asn;
 
-    let ip: IpAddr = "1.1.1.1".parse().unwrap();
+    let ip: IpAddr = "1.1.1.1".parse().expect("valid IP address");
     let result = asn_service.lookup(ip).await;
 
     // Only skip in CI environments where network may be unreliable
@@ -143,11 +146,11 @@ async fn test_private_ip_handling() {
     let ftr = Ftr::new();
 
     // Test with private IP
-    let private_ip: IpAddr = "192.168.1.1".parse().unwrap();
+    let private_ip: IpAddr = "192.168.1.1".parse().expect("valid IP address");
     let result = ftr.lookup_asn(private_ip).await;
 
     assert!(result.is_ok());
-    let asn_info = result.unwrap();
+    let asn_info = result.expect("ASN lookup should succeed");
     assert_eq!(asn_info.asn, 0); // Private IPs have ASN 0
     assert_eq!(asn_info.name, "Private Network");
 }

--- a/tests/test_ci_network.rs
+++ b/tests/test_ci_network.rs
@@ -18,7 +18,7 @@ mod tests {
         // Check basic connectivity with ping
         eprintln!("\nTesting ping to 8.8.8.8:");
         let output = Command::new("ping")
-            .args(&["-c", "1", "-W", "1", "8.8.8.8"])
+            .args(["-c", "1", "-W", "1", "8.8.8.8"])
             .output();
 
         match output {
@@ -37,7 +37,7 @@ mod tests {
         // Check traceroute
         eprintln!("\nTesting traceroute to 8.8.8.8:");
         let output = Command::new("traceroute")
-            .args(&["-n", "-m", "3", "-w", "1", "8.8.8.8"])
+            .args(["-n", "-m", "3", "-w", "1", "8.8.8.8"])
             .output();
 
         match output {
@@ -53,7 +53,7 @@ mod tests {
 
         // Check network interfaces
         eprintln!("\nNetwork interfaces:");
-        let output = Command::new("ip").args(&["addr", "show"]).output();
+        let output = Command::new("ip").args(["addr", "show"]).output();
 
         match output {
             Ok(output) => {
@@ -83,7 +83,7 @@ mod tests {
 
         // Check routing table
         eprintln!("\nRouting table:");
-        let output = Command::new("ip").args(&["route", "show"]).output();
+        let output = Command::new("ip").args(["route", "show"]).output();
 
         match output {
             Ok(output) => {
@@ -93,7 +93,7 @@ mod tests {
             }
             Err(_) => {
                 // Try netstat as fallback
-                if let Ok(output) = Command::new("netstat").args(&["-rn"]).output() {
+                if let Ok(output) = Command::new("netstat").args(["-rn"]).output() {
                     if output.status.success() {
                         eprintln!("  (via netstat -rn)");
                         eprintln!("{}", String::from_utf8_lossy(&output.stdout));

--- a/tests/traceroute_integration.rs
+++ b/tests/traceroute_integration.rs
@@ -5,7 +5,7 @@ use predicates::prelude::*;
 
 #[test]
 fn test_traceroute_to_localhost() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args([
         "--start-ttl",
         "1",
@@ -15,7 +15,7 @@ fn test_traceroute_to_localhost() {
         "localhost",
     ]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     // Localhost should resolve to 127.0.0.1
     if output.status.success() {
@@ -26,7 +26,7 @@ fn test_traceroute_to_localhost() {
 
 #[test]
 fn test_traceroute_with_multiple_queries() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args([
         "--queries",
         "2",
@@ -44,7 +44,7 @@ fn test_traceroute_with_multiple_queries() {
 
 #[test]
 fn test_udp_mode_with_custom_port() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args([
         "--protocol",
         "udp",
@@ -57,7 +57,7 @@ fn test_udp_mode_with_custom_port() {
         "127.0.0.1",
     ]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     // Check if port is being used (in verbose mode we would see it)
     // For now, just verify command accepts the parameters
@@ -70,7 +70,7 @@ fn test_udp_mode_with_custom_port() {
 
 #[test]
 fn test_no_rdns_flag() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args([
         "--no-rdns",
         "--start-ttl",
@@ -80,7 +80,7 @@ fn test_no_rdns_flag() {
         "8.8.8.8",
     ]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -91,7 +91,7 @@ fn test_no_rdns_flag() {
 
 #[test]
 fn test_no_enrich_flag() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args([
         "--no-enrich",
         "--start-ttl",
@@ -101,7 +101,7 @@ fn test_no_enrich_flag() {
         "8.8.8.8",
     ]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -113,7 +113,7 @@ fn test_no_enrich_flag() {
 
 #[test]
 fn test_json_output_structure() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args([
         "--json",
         "--start-ttl",
@@ -124,7 +124,7 @@ fn test_json_output_structure() {
         "127.0.0.1",
     ]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -132,14 +132,24 @@ fn test_json_output_structure() {
 
         // Verify JSON structure
         assert!(json["version"].is_string());
-        let version = json["version"].as_str().unwrap();
+        let version = json["version"]
+            .as_str()
+            .expect("version field should be a string");
         // Version should be in format X.Y.Z or X.Y.Z-UNRELEASED
         assert!(version.chars().filter(|c| *c == '.').count() >= 2);
         if cfg!(debug_assertions) {
             assert!(version.ends_with("-UNRELEASED"));
         }
-        assert_eq!(json["target"].as_str().unwrap(), "127.0.0.1");
-        assert_eq!(json["target_ip"].as_str().unwrap(), "127.0.0.1");
+        assert_eq!(
+            json["target"].as_str().expect("target should be a string"),
+            "127.0.0.1"
+        );
+        assert_eq!(
+            json["target_ip"]
+                .as_str()
+                .expect("target_ip should be a string"),
+            "127.0.0.1"
+        );
         assert!(json["hops"].is_array());
         assert!(json["protocol"].is_string());
         assert!(json["socket_mode"].is_string());
@@ -159,7 +169,7 @@ fn test_json_output_structure() {
 
 #[test]
 fn test_invalid_hostname() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["this-is-not-a-valid-hostname-12345.invalid"]);
 
     cmd.assert()
@@ -172,10 +182,10 @@ fn test_socket_mode_requires_permissions() {
     // Test that raw socket mode fails appropriately without root
     // This is a CLI test, so we just verify it exits with error status
     // The actual structured error testing is done in error_handling_test.rs
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["--socket-mode", "raw", "127.0.0.1"]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     // If we're not root, this should fail
     // If we are root, it might succeed or fail for other reasons

--- a/tests/v6_features_test.rs
+++ b/tests/v6_features_test.rs
@@ -1,11 +1,12 @@
-/// Integration tests for v0.6.0 features
+//! Integration tests for v0.6.0 features
+
 use ftr::{Ftr, SegmentType, TracerouteConfig};
 use std::net::Ipv4Addr;
 
 #[tokio::test]
 async fn test_v6_segment_types() {
     // Test that the new segment types are properly exposed in the API
-    let segments = vec![
+    let segments = [
         SegmentType::Lan,
         SegmentType::Isp,
         SegmentType::Transit,     // New in v0.6.0
@@ -38,9 +39,12 @@ async fn test_destination_asn_field() {
         .enable_asn_lookup(false) // Disable to make test faster
         .enable_rdns(false)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
-    let result = ftr.trace_with_config(config).await.unwrap();
+    let result = ftr
+        .trace_with_config(config)
+        .await
+        .expect("localhost trace should succeed");
 
     // Verify the destination_asn field exists (will be None without enrichment)
     assert!(
@@ -65,9 +69,12 @@ async fn test_transit_segment_classification() {
         .enable_asn_lookup(false)
         .enable_rdns(false)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
-    let result = ftr.trace_with_config(config).await.unwrap();
+    let result = ftr
+        .trace_with_config(config)
+        .await
+        .expect("localhost trace should succeed");
 
     // Check that segment types are properly set
     for hop in &result.hops {
@@ -85,14 +92,12 @@ async fn test_transit_segment_classification() {
 #[test]
 fn test_segment_serialization() {
     // Test that segment types serialize correctly for JSON output
-    use serde_json;
-
     let transit = SegmentType::Transit;
     let destination = SegmentType::Destination;
 
     // These should serialize to strings
-    let transit_json = serde_json::to_string(&transit).unwrap();
-    let dest_json = serde_json::to_string(&destination).unwrap();
+    let transit_json = serde_json::to_string(&transit).expect("Transit should serialize");
+    let dest_json = serde_json::to_string(&destination).expect("Destination should serialize");
 
     assert_eq!(
         transit_json, "\"Transit\"",
@@ -164,9 +169,12 @@ async fn test_localhost_trace_segments() {
         .enable_asn_lookup(false)
         .enable_rdns(false)
         .build()
-        .unwrap();
+        .expect("failed to build traceroute config");
 
-    let result = ftr.trace_with_config(config).await.unwrap();
+    let result = ftr
+        .trace_with_config(config)
+        .await
+        .expect("localhost trace should succeed");
 
     // Localhost should have at least one hop
     assert!(!result.hops.is_empty(), "Localhost trace should have hops");

--- a/tests/windows_integration.rs
+++ b/tests/windows_integration.rs
@@ -7,7 +7,7 @@ use predicates::prelude::*;
 
 #[test]
 fn test_windows_localhost_trace() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["--max-hops", "1", "127.0.0.1"]);
 
     cmd.assert()
@@ -17,7 +17,7 @@ fn test_windows_localhost_trace() {
 
 #[test]
 fn test_windows_icmp_mode() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["-v", "--max-hops", "1", "127.0.0.1"]);
 
     cmd.assert()
@@ -27,10 +27,10 @@ fn test_windows_icmp_mode() {
 
 #[test]
 fn test_windows_gateway_detection() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["--max-hops", "1", "8.8.8.8"]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -59,10 +59,10 @@ fn test_windows_gateway_detection() {
 
 #[test]
 fn test_windows_json_output() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["--json", "--max-hops", "1", "127.0.0.1"]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
     assert!(output.status.success());
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -76,12 +76,12 @@ fn test_windows_json_output() {
 
 #[test]
 fn test_windows_dns_resolution() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["--max-hops", "1", "localhost"]);
 
     // The test should fail because "localhost" is being treated as invalid
     // This is a bug in the DNS resolution that needs to be investigated
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     // For now, just check that it processes localhost in some way
     // Either it succeeds (resolving to 127.0.0.1) or fails with an error
@@ -93,7 +93,7 @@ fn test_windows_dns_resolution() {
 
 #[test]
 fn test_windows_invalid_host() {
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.arg("invalid.host.that.does.not.exist.example");
 
     cmd.assert()
@@ -109,7 +109,7 @@ fn test_windows_timeout_handling() {
         return;
     }
 
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args([
         "--probe-timeout-ms",
         "1", // Very short timeout
@@ -119,7 +119,7 @@ fn test_windows_timeout_handling() {
     ]);
 
     // Should complete even with very short timeout
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
     // Either succeeds or fails gracefully (not panic/crash)
     assert!(
         output.status.success() || !output.stderr.is_empty(),
@@ -135,10 +135,10 @@ fn test_windows_asn_lookup() {
         return;
     }
 
-    let mut cmd = Command::cargo_bin("ftr").unwrap();
+    let mut cmd = Command::cargo_bin("ftr").expect("ftr binary should be built");
     cmd.args(["--max-hops", "18", "8.8.8.8"]);
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to run ftr");
 
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
## Summary

Pays down all clippy lint debt in `tests/` and `benches/`, then tightens the CI Clippy job to `cargo clippy --all-targets -- -D warnings` so test/bench lint debt cannot re-accumulate. No behavior changes: all assertions are equivalent to before.

## Fixes by category

| Lint | Count | Fix |
|---|---|---|
| `clippy::unwrap_used` (incl. `unwrap_err`) | ~125 | `expect()` / `expect_err()` with meaningful messages (project convention) |
| `clippy::panic` | 13 | Restructured to `expect()` / `expect_err()` / `assert!(matches!(..), "got: {:?}")` — failure output preserved |
| deprecated `criterion::black_box` | 4 | `std::hint::black_box` |
| `missing_docs` | 3 | Bench crate docs added; `///` → `//!` in `v6_features_test.rs`; `criterion_group!` output moved into a private module (no `#[allow]` needed) |
| `clippy::needless_borrow` | 12 | `.args(&[..])` → `.args([..])`, `trace(&"")` → `trace("")` |
| `clippy::redundant_pattern_matching` | 1 | `while let Some(_) = ..` → `.is_some()` |
| `clippy::useless_vec` | 1 | `vec![..]` → array |
| `clippy::len_zero` | 1 | `len() >= 1` → `!is_empty()` |
| `clippy::assertions_on_constants` | 1 | Removed placeholder `assert!(true)` in `ci_filter_test.rs` (test presence is the point) |

Also removed the pre-existing file-level `#![allow(clippy::unwrap_used)]` from `tests/cli_integration.rs` and `tests/edge_cases.rs` and fixed the underlying unwraps.

## CI gate

The Clippy job now runs `cargo clippy --all-targets -- -D warnings` (SHA-pinned actions untouched, job otherwise unchanged; actionlint clean).

**Merge-order note:** `--all-targets` also lints `#[cfg(test)]` modules in `src/` (e.g. `src/traceroute/api.rs`, `src/enrichment/service.rs`, `src/asn/cache.rs`, ~100 findings), which are being fixed on separate branches. The Clippy CI job will fail on this PR until those land — merge those first (or merge this last).

## Platform-gated files

`tests/windows_integration.rs`, `tests/freebsd_integration.rs`, and `tests/freebsd_smoke.rs` received the same mechanical `unwrap()` → `expect()` / `&[..]` → `[..]` treatment. They only compile on their target platforms; the identical pattern compiles and passes on macOS/Linux targets in this PR, but they have not been compiled on Windows/FreeBSD locally — CI's platform jobs will verify.

## Validation

- `cargo clippy --all-targets --keep-going -- -D warnings`: zero findings in `tests/` and `benches/`
- `cargo fmt -- --check`: clean
- `cargo test`: all targets pass, 0 failures (live-network tests included, no flakes)
- `actionlint .github/workflows/ci.yml`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)