### PR TITLE
feat: Refreshable system DNS configuration

### DIFF
--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -11,8 +11,8 @@ pub mod test_utils;
 
 pub use cache::RdnsCache;
 pub use resolver::{
-    resolve_a, resolve_a_with_servers, resolve_ptr, resolve_ptr_with_servers, resolve_txt,
-    resolve_txt_with_servers,
+    refresh_system_dns, resolve_a, resolve_a_with_servers, resolve_ptr, resolve_ptr_with_servers,
+    resolve_txt, resolve_txt_with_servers,
 };
 pub use reverse::ReverseDnsError;
 pub use service::RdnsLookup;

--- a/src/dns/resolver.rs
+++ b/src/dns/resolver.rs
@@ -4,7 +4,7 @@
 //! Replaces hickory-resolver for the small set of queries ftr needs.
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::sync::OnceLock;
+use std::sync::{Arc, RwLock};
 use tokio::net::UdpSocket;
 use tokio::time::Duration;
 
@@ -101,7 +101,15 @@ struct ResolverConfig {
     timing: QueryTiming,
 }
 
-/// The default resolver configuration, computed once per process.
+/// Cached default resolver configuration; `None` until first use.
+///
+/// Guarded by an `RwLock` rather than a `OnceLock` so
+/// [`refresh_system_dns`] can swap in a re-read configuration after a
+/// network change. Queries snapshot an `Arc`, so a refresh never disturbs
+/// lookups already in flight.
+static DEFAULT_CONFIG: RwLock<Option<Arc<ResolverConfig>>> = RwLock::new(None);
+
+/// Compute the resolver configuration from system state.
 ///
 /// Server precedence: system resolvers from `/etc/resolv.conf` first
 /// (Unix only, up to [`crate::dns::system::MAXNS`]), then
@@ -109,36 +117,67 @@ struct ResolverConfig {
 /// from resolv.conf override the default timing. When no system resolvers
 /// are found — including always on Windows, where system-resolver discovery
 /// is future work — this is exactly the previous hardcoded behavior.
-fn default_config() -> &'static ResolverConfig {
-    static CONFIG: OnceLock<ResolverConfig> = OnceLock::new();
-    CONFIG.get_or_init(|| {
-        // The single place system configuration is consulted.
-        #[cfg(unix)]
-        let (mut servers, timing) = match crate::dns::system::load_system_resolv_conf() {
-            Some(conf) => {
-                let mut timing = QueryTiming::default();
-                if let Some(timeout) = conf.timeout {
-                    timing.attempt_timeout = timeout;
-                }
-                if let Some(attempts) = conf.attempts {
-                    timing.attempts = attempts;
-                }
-                (conf.nameservers, timing)
+fn compute_config() -> ResolverConfig {
+    // The single place system configuration is consulted.
+    #[cfg(unix)]
+    let (mut servers, timing) = match crate::dns::system::load_system_resolv_conf() {
+        Some(conf) => {
+            let mut timing = QueryTiming::default();
+            if let Some(timeout) = conf.timeout {
+                timing.attempt_timeout = timeout;
             }
-            None => (Vec::new(), QueryTiming::default()),
-        };
-        // Windows system-resolver discovery is future work; see crate::dns::system.
-        #[cfg(not(unix))]
-        let (mut servers, timing) = (Vec::<SocketAddr>::new(), QueryTiming::default());
-
-        for fallback in FALLBACK_DNS_SERVERS {
-            if !servers.contains(fallback) {
-                servers.push(*fallback);
+            if let Some(attempts) = conf.attempts {
+                timing.attempts = attempts;
             }
+            (conf.nameservers, timing)
         }
+        None => (Vec::new(), QueryTiming::default()),
+    };
+    // Windows system-resolver discovery is future work; see crate::dns::system.
+    #[cfg(not(unix))]
+    let (mut servers, timing) = (Vec::<SocketAddr>::new(), QueryTiming::default());
 
-        ResolverConfig { servers, timing }
-    })
+    for fallback in FALLBACK_DNS_SERVERS {
+        if !servers.contains(fallback) {
+            servers.push(*fallback);
+        }
+    }
+
+    ResolverConfig { servers, timing }
+}
+
+/// The default resolver configuration, computed on first use and cached
+/// until [`refresh_system_dns`] is called.
+fn default_config() -> Arc<ResolverConfig> {
+    if let Some(cfg) = DEFAULT_CONFIG
+        .read()
+        .expect("DNS config lock poisoned")
+        .as_ref()
+    {
+        return Arc::clone(cfg);
+    }
+    let mut slot = DEFAULT_CONFIG.write().expect("DNS config lock poisoned");
+    // Double-checked: another thread may have initialized while we waited.
+    if let Some(cfg) = slot.as_ref() {
+        return Arc::clone(cfg);
+    }
+    let cfg = Arc::new(compute_config());
+    *slot = Some(Arc::clone(&cfg));
+    cfg
+}
+
+/// Re-read system DNS configuration (e.g. `/etc/resolv.conf`).
+///
+/// Long-running library consumers should call this after a network change
+/// (VPN toggle, interface switch) so subsequent lookups use the current
+/// system resolvers; the process otherwise caches the configuration from
+/// first use. Queries already in flight are unaffected. Explicit-server
+/// lookups (`*_with_servers`) never consult this configuration.
+pub fn refresh_system_dns() {
+    // Compute outside the lock: filesystem I/O under a lock held across
+    // reads would stall concurrent lookups.
+    let cfg = Arc::new(compute_config());
+    *DEFAULT_CONFIG.write().expect("DNS config lock poisoned") = Some(cfg);
 }
 
 /// Resolve a hostname to IPv4 addresses (A record query).
@@ -1137,5 +1176,21 @@ mod tests {
             Ok(Err(e)) => eprintln!("TXT lookup failed (network unavailable): {e}"),
             Err(_) => eprintln!("TXT lookup timed out"),
         }
+    }
+
+    #[test]
+    fn test_refresh_system_dns_swaps_config() {
+        let before = default_config();
+        refresh_system_dns();
+        let after = default_config();
+        assert!(
+            !Arc::ptr_eq(&before, &after),
+            "refresh should install a freshly computed config"
+        );
+        // Content is equivalent when the underlying system config hasn't
+        // changed between the two reads.
+        assert_eq!(before.servers, after.servers);
+        assert_eq!(before.timing.attempts, after.timing.attempts);
+        assert_eq!(before.timing.attempt_timeout, after.timing.attempt_timeout);
     }
 }

--- a/src/dns/system.rs
+++ b/src/dns/system.rs
@@ -26,7 +26,7 @@
 //! configuration *changes*, long-running consumers should call
 //! [`crate::dns::refresh_system_dns`]; automatic change notification (the
 //! `notify(3)` key `com.apple.system.SystemConfiguration.dns_configuration`,
-//! as used by Chromium — see https://issues.chromium.org/issues/40182831)
+//! as used by Chromium — see <https://issues.chromium.org/issues/40182831>)
 //! is a possible future enhancement.
 
 use std::net::{IpAddr, SocketAddr};

--- a/src/dns/system.rs
+++ b/src/dns/system.rs
@@ -13,8 +13,21 @@
 //!
 //! Note for macOS: `/etc/resolv.conf` carries a notice that most processes
 //! resolve names through the system routing layer instead. It is still
-//! auto-generated with the current primary resolvers, which is exactly what
-//! a hand-rolled UDP resolver like ours needs.
+//! configd-maintained with the current *global default* resolvers, which is
+//! the right set for the public zones this resolver queries (`in-addr.arpa`
+//! / `ip6.arpa` PTR, `asn.cymru.com` TXT). What it deliberately does NOT
+//! capture are macOS *scoped* resolvers — per-interface and per-domain
+//! entries (split-DNS VPN configurations; compare `scutil --dns` against
+//! resolv.conf). Reading those requires `dns_configuration_copy()` from
+//! `dnsinfo.h`, private SPI that Apple removed from the public SDK, and
+//! honoring them would mean reimplementing mDNSResponder's per-domain query
+//! routing — deliberately out of scope. Callers on split-DNS networks can
+//! pin resolvers explicitly via the `*_with_servers` functions. On DNS
+//! configuration *changes*, long-running consumers should call
+//! [`crate::dns::refresh_system_dns`]; automatic change notification (the
+//! `notify(3)` key `com.apple.system.SystemConfiguration.dns_configuration`,
+//! as used by Chromium — see https://issues.chromium.org/issues/40182831)
+//! is a possible future enhancement.
 
 use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;


### PR DESCRIPTION
Follow-up to #31, prompted by the maintainer pointing at Chromium's macOS DNS change-notification work (https://issues.chromium.org/issues/40182831):

- **Problem**: the system resolver list was computed once per process (`OnceLock`). A long-running library consumer that switches networks or toggles a VPN keeps querying stale resolvers forever.
- **Fix**: the cached config is now an `Arc` snapshot behind an `RwLock`, with a public `dns::refresh_system_dns()` to re-read system configuration — the SwiftFTR `networkChanged()` pattern. In-flight queries keep their snapshot; `*_with_servers` lookups are unaffected. Double-checked locking on first use; the re-read happens outside the lock.
- **Docs**: `dns::system` module docs now state the macOS scoped-resolver limitation precisely (configd-maintained resolv.conf = global default resolvers, correct for our public-zone PTR/TXT lookups; scoped/split-DNS entries require `dns_configuration_copy()` private SPI, deliberately avoided; `scutil --dns` on the dev machine shows 12 resolvers vs 2 in resolv.conf). Automatic change-watching via `notify(3)` with Chromium's pinned key is recorded as future work.

Validation: `cargo clippy --all-targets -- -D warnings` (the new gate) clean, all 25 test suites pass, new unit test verifies refresh swaps the cached config, rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)