### PR TITLE
feat: IPv6 ASN lookup (Cymru origin6) and STUN v6 public-IP detection

### DIFF
--- a/src/asn/cache.rs
+++ b/src/asn/cache.rs
@@ -1,7 +1,7 @@
 //! ASN lookup caching functionality
 
 use crate::traceroute::AsnInfo;
-use ip_network::Ipv4Network;
+use ip_network::{Ipv4Network, Ipv6Network};
 use ip_network_table::IpNetworkTable;
 use std::sync::{Arc, RwLock};
 
@@ -38,8 +38,25 @@ impl AsnCache {
             .map(|(_, asn_info)| asn_info.clone())
     }
 
+    /// Look up an IPv6 address in the cache
+    ///
+    /// Longest-prefix match over cached IPv6 networks (e.g. an entry for
+    /// `2001:4860::/32` answers for `2001:4860:4860::8888`).
+    pub fn get_ipv6(&self, ip: &std::net::Ipv6Addr) -> Option<AsnInfo> {
+        let cache = self.cache.read().expect("rwlock poisoned");
+        cache
+            .longest_match(*ip)
+            .map(|(_, asn_info)| asn_info.clone())
+    }
+
     /// Insert an ASN info entry into the cache
     pub fn insert(&self, prefix: Ipv4Network, asn_info: AsnInfo) {
+        let mut cache = self.cache.write().expect("rwlock poisoned");
+        cache.insert(prefix, asn_info);
+    }
+
+    /// Insert an ASN info entry for an IPv6 prefix into the cache
+    pub fn insert_ipv6(&self, prefix: Ipv6Network, asn_info: AsnInfo) {
         let mut cache = self.cache.write().expect("rwlock poisoned");
         cache.insert(prefix, asn_info);
     }
@@ -105,6 +122,83 @@ mod tests {
         cache.clear();
         assert!(cache.is_empty());
         assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn test_asn_cache_ipv6() {
+        use std::net::Ipv6Addr;
+
+        let cache = AsnCache::new();
+
+        let asn_info = AsnInfo {
+            asn: 15169,
+            prefix: "2001:4860::/32".to_string(),
+            country_code: "US".to_string(),
+            registry: "arin".to_string(),
+            name: "GOOGLE".to_string(),
+        };
+
+        let prefix: Ipv6Network = "2001:4860::/32".parse().expect("valid prefix");
+        cache.insert_ipv6(prefix, asn_info.clone());
+        assert_eq!(cache.len(), 1);
+
+        // Longest-prefix match: an address inside the /32 hits the entry
+        let ip: Ipv6Addr = "2001:4860:4860::8888".parse().expect("valid IP");
+        let result = cache.get_ipv6(&ip);
+        assert_eq!(result.expect("cache should contain entry").asn, 15169);
+
+        // An address outside the prefix misses
+        let ip: Ipv6Addr = "2606:4700::1111".parse().expect("valid IP");
+        assert!(cache.get_ipv6(&ip).is_none());
+
+        // v4 and v6 entries coexist without cross-family hits
+        let v4_prefix: Ipv4Network = "8.8.8.0/24".parse().expect("valid prefix");
+        cache.insert(v4_prefix, asn_info.clone());
+        assert_eq!(cache.len(), 2);
+        let v4_ip: Ipv4Addr = "8.8.8.8".parse().expect("valid IP");
+        assert!(cache.get(&v4_ip).is_some());
+
+        cache.clear();
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn test_overlapping_prefixes_ipv6() {
+        use std::net::Ipv6Addr;
+
+        let cache = AsnCache::new();
+        let specific: Ipv6Network = "2001:4860:4860::/48".parse().expect("valid prefix");
+        cache.insert_ipv6(
+            specific,
+            AsnInfo {
+                asn: 1,
+                prefix: "2001:4860:4860::/48".to_string(),
+                country_code: "US".to_string(),
+                registry: "arin".to_string(),
+                name: "Specific".to_string(),
+            },
+        );
+        let broader: Ipv6Network = "2001:4860::/32".parse().expect("valid prefix");
+        cache.insert_ipv6(
+            broader,
+            AsnInfo {
+                asn: 2,
+                prefix: "2001:4860::/32".to_string(),
+                country_code: "US".to_string(),
+                registry: "arin".to_string(),
+                name: "Broader".to_string(),
+            },
+        );
+
+        // Should match the most specific prefix
+        let ip: Ipv6Addr = "2001:4860:4860::8888".parse().expect("valid IP");
+        let result = cache.get_ipv6(&ip);
+        assert_eq!(result.expect("cache should contain entry").asn, 1);
+
+        // Outside the /48 but inside the /32 hits the broader entry
+        let ip: Ipv6Addr = "2001:4860:4802::1".parse().expect("valid IP");
+        let result = cache.get_ipv6(&ip);
+        assert_eq!(result.expect("cache should contain entry").asn, 2);
     }
 
     #[test]

--- a/src/asn/lookup.rs
+++ b/src/asn/lookup.rs
@@ -3,8 +3,8 @@
 use crate::asn::cache::AsnCache;
 use crate::dns::resolver;
 use crate::traceroute::{AsnInfo, is_cgnat, is_internal_ip};
-use ip_network::Ipv4Network;
-use std::net::Ipv4Addr;
+use ip_network::{Ipv4Network, Ipv6Network};
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -26,6 +26,148 @@ pub enum AsnLookupError {
     /// No ASN data found
     #[error("No ASN data found")]
     NotFound,
+}
+
+/// Parsed fields of a Team Cymru origin/origin6 TXT payload.
+///
+/// Both the v4 (`origin.asn.cymru.com`) and v6 (`origin6.asn.cymru.com`)
+/// zones use the same payload format:
+/// `"AS | prefix | CC | registry | allocated"`
+/// (<https://www.team-cymru.com/ip-asn-mapping>).
+struct CymruOrigin {
+    asn: u32,
+    prefix: String,
+    country_code: String,
+    registry: String,
+}
+
+/// Parse a Cymru origin TXT payload into its fields.
+///
+/// Multi-origin prefixes list several ASNs space-separated in the first
+/// field (e.g. `"15169 36040 | ..."`); the first ASN is used.
+fn parse_cymru_origin_txt(txt: &str) -> Result<CymruOrigin, AsnLookupError> {
+    let parts: Vec<&str> = txt.split('|').map(str::trim).collect();
+    if parts.len() < 3 {
+        return Err(AsnLookupError::InvalidFormat);
+    }
+
+    // Parse ASN as u32, handling a potential "AS" prefix and taking the
+    // first ASN of a multi-origin list.
+    let asn_str = parts[0]
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .trim_start_matches("AS");
+    let asn = asn_str.parse::<u32>().unwrap_or(0);
+
+    Ok(CymruOrigin {
+        asn,
+        prefix: parts[1].to_string(),
+        country_code: parts[2].to_string(),
+        registry: if parts.len() > 3 {
+            parts[3].to_string()
+        } else {
+            String::new()
+        },
+    })
+}
+
+/// Query a Cymru origin zone name and parse the first TXT payload.
+async fn query_cymru_origin(query: &str) -> Result<CymruOrigin, AsnLookupError> {
+    let txts = resolver::resolve_txt(query)
+        .await
+        .map_err(|e| AsnLookupError::DnsError(e.to_string()))?;
+    let txt_data = txts.first().ok_or(AsnLookupError::NotFound)?;
+    parse_cymru_origin_txt(txt_data)
+}
+
+/// Look up the AS organization name via `AS{asn}.asn.cymru.com`.
+///
+/// Returns an empty string on any failure: the name is display-only
+/// enrichment and must never fail the whole lookup.
+async fn lookup_as_name(asn: u32, country_code: &str) -> String {
+    let as_query = format!("AS{asn}.asn.cymru.com");
+    match resolver::resolve_txt(&as_query).await {
+        Ok(as_txts) => {
+            if let Some(as_txt) = as_txts.first() {
+                let as_parts: Vec<&str> = as_txt.split('|').map(str::trim).collect();
+                if as_parts.len() >= 5 {
+                    // Format is: ASN | CC | Registry | Allocated | AS Name
+                    let mut as_name = as_parts[4].to_string();
+                    // Team Cymru often includes ", CC" at the end of the name - remove it
+                    if as_name.ends_with(&format!(", {country_code}")) {
+                        as_name.truncate(as_name.len() - country_code.len() - 2);
+                    }
+                    as_name
+                } else if as_parts.len() >= 2 {
+                    as_parts[1].to_string()
+                } else {
+                    String::new()
+                }
+            } else {
+                String::new()
+            }
+        }
+        Err(_) => String::new(),
+    }
+}
+
+/// Build the Team Cymru `origin6.asn.cymru.com` query name for an IPv6
+/// address: all 32 hex nibbles of the fully expanded address become labels,
+/// least-significant nibble first
+/// (<https://www.team-cymru.com/ip-asn-mapping>).
+///
+/// e.g. `2001:4860:4860::8888` becomes
+/// `8.8.8.8.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.6.8.4.0.6.8.4.1.0.0.2.origin6.asn.cymru.com`.
+///
+/// Validated against the live zone by `examples/spike_asn6.rs`.
+fn origin6_query_name(addr: &Ipv6Addr) -> String {
+    const SUFFIX: &str = "origin6.asn.cymru.com";
+    let mut name = String::with_capacity(32 * 2 + SUFFIX.len());
+    for byte in addr.octets().iter().rev() {
+        // Low nibble first: it is the less significant of the pair and the
+        // whole name runs least-significant-nibble first.
+        name.push_str(&format!("{:x}.{:x}.", byte & 0x0f, byte >> 4));
+    }
+    name.push_str(SUFFIX);
+    name
+}
+
+/// Classify a non-routable IPv6 address, returning the human-readable name
+/// used in the typed "private/reserved" [`AsnInfo`] outcome (matching the
+/// v4 RFC 1918 handling), or `None` if the address is globally routable and
+/// therefore worth a Cymru query.
+///
+/// Note: v4-mapped addresses (`::ffff:0:0/96`) are handled separately in
+/// [`lookup_asn_v6_with_cache`], which defers to the v4 path for the
+/// embedded address.
+///
+/// Ranges (IANA IPv6 Special-Purpose Address Registry):
+/// - `::1/128` loopback (RFC 4291 §2.5.3)
+/// - `::/128` unspecified (RFC 4291 §2.5.2)
+/// - `fe80::/10` link-local unicast (RFC 4291 §2.5.6)
+/// - `fc00::/7` unique local addresses (RFC 4193) — the v6 analog of RFC 1918
+/// - `2001:db8::/32` documentation (RFC 3849)
+/// - `ff00::/8` multicast (RFC 4291 §2.7)
+fn special_ipv6_name(addr: &Ipv6Addr) -> Option<&'static str> {
+    let seg = addr.segments();
+    if addr.is_loopback() {
+        Some("Loopback")
+    } else if (seg[0] & 0xfe00) == 0xfc00 {
+        // fc00::/7 unique local: mask the top 7 bits of the first hextet
+        Some("Private Network")
+    } else if addr.is_unspecified()
+        // fe80::/10 link-local: mask the top 10 bits of the first hextet
+        || (seg[0] & 0xffc0) == 0xfe80
+        // 2001:db8::/32 documentation: exact first two hextets
+        || (seg[0] == 0x2001 && seg[1] == 0xdb8)
+        // ff00::/8 multicast: mask the top 8 bits of the first hextet
+        || (seg[0] & 0xff00) == 0xff00
+    {
+        Some("Special Use")
+    } else {
+        None
+    }
 }
 
 /// Performs ASN lookup using Team Cymru's whois service with injected cache
@@ -84,71 +226,97 @@ pub(crate) async fn lookup_asn_with_cache(
         "{}.{}.{}.{}.origin.asn.cymru.com",
         octets[3], octets[2], octets[1], octets[0]
     );
-
-    let txts = resolver::resolve_txt(&query)
-        .await
-        .map_err(|e| AsnLookupError::DnsError(e.to_string()))?;
-
-    let txt_data = txts.first().ok_or(AsnLookupError::NotFound)?;
-
-    let parts: Vec<&str> = txt_data.split('|').map(str::trim).collect();
-    if parts.len() < 3 {
-        return Err(AsnLookupError::InvalidFormat);
-    }
-
-    // Parse ASN as u32, handling potential "AS" prefix
-    let asn_str = parts[0].trim_start_matches("AS");
-    let asn = asn_str.parse::<u32>().unwrap_or(0);
-    let prefix = parts[1].to_string();
-    let country_code = parts[2].to_string();
-    let registry = if parts.len() > 3 {
-        parts[3].to_string()
-    } else {
-        String::new()
-    };
+    let origin = query_cymru_origin(&query).await?;
 
     // Parse prefix to create Ipv4Network
-    let net = prefix
+    let net = origin
+        .prefix
         .parse::<Ipv4Network>()
         .map_err(|_| AsnLookupError::InvalidFormat)?;
 
     // Query for AS name
-    let as_query = format!("AS{asn}.asn.cymru.com");
-    let name = match resolver::resolve_txt(&as_query).await {
-        Ok(as_txts) => {
-            if let Some(as_txt) = as_txts.first() {
-                let as_parts: Vec<&str> = as_txt.split('|').map(str::trim).collect();
-                if as_parts.len() >= 5 {
-                    // Format is: ASN | CC | Registry | Allocated | AS Name
-                    let mut as_name = as_parts[4].to_string();
-                    // Team Cymru often includes ", CC" at the end of the name - remove it
-                    if as_name.ends_with(&format!(", {}", country_code)) {
-                        as_name.truncate(as_name.len() - country_code.len() - 2);
-                    }
-                    as_name
-                } else if as_parts.len() >= 2 {
-                    as_parts[1].to_string()
-                } else {
-                    String::new()
-                }
-            } else {
-                String::new()
-            }
-        }
-        Err(_) => String::new(),
-    };
+    let name = lookup_as_name(origin.asn, &origin.country_code).await;
 
     let asn_info = AsnInfo {
-        asn,
-        prefix: prefix.clone(),
-        country_code,
-        registry,
+        asn: origin.asn,
+        prefix: origin.prefix,
+        country_code: origin.country_code,
+        registry: origin.registry,
         name,
     };
 
     // Cache the result
     let cache_write = cache.write().await;
     cache_write.insert(net, asn_info.clone());
+
+    Ok(asn_info)
+}
+
+/// Performs IPv6 ASN lookup via Team Cymru's `origin6.asn.cymru.com` zone
+/// with injected cache (Internal use only - users should use AsnLookup
+/// service)
+pub(crate) async fn lookup_asn_v6_with_cache(
+    ipv6_addr: Ipv6Addr,
+    cache: &Arc<RwLock<AsnCache>>,
+) -> Result<AsnInfo, AsnLookupError> {
+    // v4-mapped addresses (::ffff:0:0/96, RFC 4291 §2.5.5.2) carry an
+    // embedded IPv4 address: defer to the v4 path (including its RFC 1918
+    // handling) so ::ffff:8.8.8.8 and 8.8.8.8 resolve identically.
+    if let Some(v4) = ipv6_addr.to_ipv4_mapped() {
+        return lookup_asn_with_cache(v4, cache).await;
+    }
+
+    // Check for non-routable ranges first, before cache — same typed
+    // "private/reserved" outcome as the v4 special-IP handling.
+    if let Some(name) = special_ipv6_name(&ipv6_addr) {
+        let asn_info = AsnInfo {
+            asn: 0, // 0 indicates N/A for private/special IPs
+            prefix: format!("{ipv6_addr}/128"),
+            country_code: "N/A".to_string(),
+            registry: "N/A".to_string(),
+            name: name.to_string(),
+        };
+
+        // Cache the result
+        if let Ok(net) = asn_info.prefix.parse::<Ipv6Network>() {
+            let cache_write = cache.write().await;
+            cache_write.insert_ipv6(net, asn_info.clone());
+        }
+
+        return Ok(asn_info);
+    }
+
+    // Check cache for routable IPs
+    {
+        let cache_read = cache.read().await;
+        if let Some(cached) = cache_read.get_ipv6(&ipv6_addr) {
+            return Ok(cached);
+        }
+    }
+
+    // Query Team Cymru DNS (origin6 zone, nibble-reversed name)
+    let origin = query_cymru_origin(&origin6_query_name(&ipv6_addr)).await?;
+
+    // Parse prefix to create Ipv6Network
+    let net = origin
+        .prefix
+        .parse::<Ipv6Network>()
+        .map_err(|_| AsnLookupError::InvalidFormat)?;
+
+    // Query for AS name
+    let name = lookup_as_name(origin.asn, &origin.country_code).await;
+
+    let asn_info = AsnInfo {
+        asn: origin.asn,
+        prefix: origin.prefix,
+        country_code: origin.country_code,
+        registry: origin.registry,
+        name,
+    };
+
+    // Cache the result
+    let cache_write = cache.write().await;
+    cache_write.insert_ipv6(net, asn_info.clone());
 
     Ok(asn_info)
 }

--- a/src/asn/lookup_tests.rs
+++ b/src/asn/lookup_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for ASN lookup functionality
 
 use super::*;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -146,6 +146,148 @@ async fn test_cache_multiple_ips_same_prefix() {
 
     assert_eq!(result1.expect("r1").name, "Private Network");
     assert_eq!(result2.expect("r2").name, "Private Network");
+}
+
+#[test]
+fn test_origin6_query_name_full_expansion() {
+    // The full 32-nibble expansion of 2001:4860:4860::8888, least
+    // significant nibble first — exact string validated against the live
+    // Cymru zone by examples/spike_asn6.rs.
+    let addr: Ipv6Addr = "2001:4860:4860::8888".parse().expect("valid IP");
+    assert_eq!(
+        origin6_query_name(&addr),
+        "8.8.8.8.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.6.8.4.0.6.8.4.1.0.0.2.origin6.asn.cymru.com"
+    );
+}
+
+#[test]
+fn test_origin6_query_name_loopback() {
+    let addr: Ipv6Addr = "::1".parse().expect("valid IP");
+    assert_eq!(
+        origin6_query_name(&addr),
+        "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.origin6.asn.cymru.com"
+    );
+}
+
+#[test]
+fn test_parse_cymru_origin_txt() {
+    // Payload observed live from the origin6 zone (docs/IPV6_DESIGN.md)
+    let origin = parse_cymru_origin_txt("15169 | 2001:4860::/32 | US | arin | 2005-03-14")
+        .expect("valid payload");
+    assert_eq!(origin.asn, 15169);
+    assert_eq!(origin.prefix, "2001:4860::/32");
+    assert_eq!(origin.country_code, "US");
+    assert_eq!(origin.registry, "arin");
+
+    // Multi-origin prefixes list several ASNs; the first is used
+    let origin = parse_cymru_origin_txt("15169 36040 | 8.8.8.0/24 | US | arin | 2023-12-28")
+        .expect("valid payload");
+    assert_eq!(origin.asn, 15169);
+
+    // Too few fields is a format error
+    assert!(matches!(
+        parse_cymru_origin_txt("15169 | 2001:4860::/32"),
+        Err(AsnLookupError::InvalidFormat)
+    ));
+}
+
+#[test]
+fn test_special_ipv6_classification() {
+    let cases: &[(&str, Option<&str>)] = &[
+        ("::1", Some("Loopback")),
+        ("::", Some("Special Use")),
+        // fe80::/10 link-local, including the top of the range (febf::)
+        ("fe80::1", Some("Special Use")),
+        ("febf:ffff::1", Some("Special Use")),
+        // fc00::/7 unique local (both halves)
+        ("fc00::1", Some("Private Network")),
+        ("fd12:3456:789a::1", Some("Private Network")),
+        // 2001:db8::/32 documentation
+        ("2001:db8::1", Some("Special Use")),
+        // ff00::/8 multicast
+        ("ff02::1", Some("Special Use")),
+        // Routable addresses must NOT short-circuit
+        ("2001:4860:4860::8888", None),
+        ("2606:4700::1111", None),
+        // Just outside reserved ranges
+        ("fe00::1", None),     // below fe80::/10
+        ("fec0::1", None),     // above fe80::/10 (old site-local, routable per this filter)
+        ("2001:db9::1", None), // adjacent to documentation range
+    ];
+    for (addr_str, expected) in cases {
+        let addr: Ipv6Addr = addr_str.parse().expect("valid IP");
+        assert_eq!(
+            special_ipv6_name(&addr),
+            *expected,
+            "wrong classification for {addr_str}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_lookup_v6_special_ranges_no_network() {
+    // Reserved ranges short-circuit before any DNS query, so these run
+    // offline. Each yields the typed asn=0 outcome like the v4 path.
+    let cache = Arc::new(RwLock::new(crate::asn::cache::AsnCache::new()));
+    let cases: &[(&str, &str)] = &[
+        ("::1", "Loopback"),
+        ("::", "Special Use"),
+        ("fe80::1", "Special Use"),
+        ("fd00::1", "Private Network"),
+        ("2001:db8::1", "Special Use"),
+        ("ff02::1", "Special Use"),
+    ];
+    for (addr_str, expected_name) in cases {
+        let addr: Ipv6Addr = addr_str.parse().expect("valid IP");
+        let info = lookup_asn_v6_with_cache(addr, &cache)
+            .await
+            .expect("special range lookup should not fail");
+        assert_eq!(info.asn, 0, "ASN should be 0 for {addr_str}");
+        assert_eq!(info.name, *expected_name, "wrong name for {addr_str}");
+        assert_eq!(info.prefix, format!("{addr}/128"));
+    }
+}
+
+#[tokio::test]
+async fn test_lookup_v6_v4_mapped_defers_to_v4_path() {
+    // ::ffff:0:0/96 embeds an IPv4 address; the v4 path's RFC 1918 handling
+    // must apply to the embedded address (offline: private range).
+    let cache = Arc::new(RwLock::new(crate::asn::cache::AsnCache::new()));
+    let addr: Ipv6Addr = "::ffff:192.168.1.1".parse().expect("valid IP");
+    let info = lookup_asn_v6_with_cache(addr, &cache)
+        .await
+        .expect("v4-mapped lookup should not fail");
+    assert_eq!(info.asn, 0);
+    assert_eq!(info.name, "Private Network");
+    // The v4 path answered: prefix is the v4 form, not a /128
+    assert_eq!(info.prefix, "192.168.1.1/32");
+}
+
+#[tokio::test]
+async fn test_lookup_v6_uses_cached_prefix_no_network() {
+    // Pre-populate the cache with Google's /32; the lookup must be answered
+    // from cache (no DNS involved, so a wrong answer or network dependence
+    // would fail deterministically).
+    let cache = Arc::new(RwLock::new(crate::asn::cache::AsnCache::new()));
+    {
+        let cache_write = cache.write().await;
+        cache_write.insert_ipv6(
+            "2001:4860::/32".parse().expect("valid prefix"),
+            AsnInfo {
+                asn: 15169,
+                prefix: "2001:4860::/32".to_string(),
+                country_code: "US".to_string(),
+                registry: "arin".to_string(),
+                name: "GOOGLE".to_string(),
+            },
+        );
+    }
+    let addr: Ipv6Addr = "2001:4860:4860::8888".parse().expect("valid IP");
+    let info = lookup_asn_v6_with_cache(addr, &cache)
+        .await
+        .expect("cached lookup should succeed");
+    assert_eq!(info.asn, 15169);
+    assert_eq!(info.name, "GOOGLE");
 }
 
 #[test]

--- a/src/asn/service.rs
+++ b/src/asn/service.rs
@@ -4,16 +4,18 @@
 //! abstracting away the caching implementation details.
 
 use super::cache::AsnCache;
-use super::lookup::{AsnLookupError, lookup_asn_with_cache};
+use super::lookup::{AsnLookupError, lookup_asn_v6_with_cache, lookup_asn_with_cache};
 use crate::traceroute::AsnInfo;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 /// ASN (Autonomous System Number) lookup service
 ///
-/// This service provides ASN information for IPv4 addresses using Team Cymru's
-/// whois service. It internally caches results to improve performance.
+/// This service provides ASN information for IPv4 and IPv6 addresses using
+/// Team Cymru's whois service (`origin.asn.cymru.com` for v4,
+/// `origin6.asn.cymru.com` for v6). It internally caches results to improve
+/// performance.
 ///
 /// # Examples
 ///
@@ -56,13 +58,18 @@ impl AsnLookup {
     pub async fn lookup(&self, ip: IpAddr) -> Result<AsnInfo, AsnLookupError> {
         match ip {
             IpAddr::V4(ipv4) => lookup_asn_with_cache(ipv4, &self.cache).await,
-            IpAddr::V6(_) => Err(AsnLookupError::NotFound),
+            IpAddr::V6(ipv6) => lookup_asn_v6_with_cache(ipv6, &self.cache).await,
         }
     }
 
     /// Look up ASN information for an IPv4 address
     pub async fn lookup_ipv4(&self, ip: Ipv4Addr) -> Result<AsnInfo, AsnLookupError> {
         self.lookup(IpAddr::V4(ip)).await
+    }
+
+    /// Look up ASN information for an IPv6 address
+    pub async fn lookup_ipv6(&self, ip: Ipv6Addr) -> Result<AsnInfo, AsnLookupError> {
+        self.lookup(IpAddr::V6(ip)).await
     }
 
     /// Clear all cached ASN information
@@ -84,6 +91,15 @@ impl AsnLookup {
     pub async fn is_cached(&self, ip: &Ipv4Addr) -> bool {
         let cache = self.cache.read().await;
         cache.get(ip).is_some()
+    }
+
+    /// Check if an IP address (either family) is in the cache
+    pub async fn is_cached_ip(&self, ip: &IpAddr) -> bool {
+        let cache = self.cache.read().await;
+        match ip {
+            IpAddr::V4(ipv4) => cache.get(ipv4).is_some(),
+            IpAddr::V6(ipv6) => cache.get_ipv6(ipv6).is_some(),
+        }
     }
 }
 

--- a/src/enrichment/service.rs
+++ b/src/enrichment/service.rs
@@ -163,10 +163,16 @@ mod tests {
         assert!(results.contains_key(&ipv6_addr));
         let result = &results[&ipv6_addr];
 
-        // IPv6 ASN lookups aren't supported yet, so asn_info should be None
-        assert!(result.asn_info.is_none());
+        // IPv6 ASN lookups are supported via Team Cymru's origin6 zone:
+        // with network access this enriches to Google's AS15169. asn_info
+        // is None only when the live lookup failed (offline environment).
+        if let Some(asn_info) = &result.asn_info {
+            assert_eq!(asn_info.asn, 15169, "Google DNS v6 should be AS15169");
+        } else {
+            eprintln!("test_ipv6_enrichment: no ASN info (offline?); skipping ASN assertion");
+        }
 
-        // But DNS lookup should work
+        // DNS lookup should work
         assert_eq!(result.addr, ipv6_addr);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,8 +307,8 @@ impl Ftr {
     /// This is a convenience method that provides direct access to the ASN
     /// lookup service without needing to interact with `Arc<RwLock>`.
     ///
-    /// Note: Currently only IPv4 is supported. IPv6 addresses will return
-    /// an error.
+    /// Both IPv4 and IPv6 addresses are supported (IPv6 lookups use Team
+    /// Cymru's `origin6.asn.cymru.com` zone).
     ///
     /// # Arguments
     ///
@@ -401,6 +401,53 @@ impl Ftr {
         &self,
     ) -> Result<std::net::IpAddr, crate::public_ip::providers::PublicIpError> {
         self.services.stun.get_public_ip().await
+    }
+
+    /// Get the public IPv6 address of this machine
+    ///
+    /// This is a convenience method that uses STUN over UDPv6 to detect
+    /// the public IPv6 address as seen from the internet. Fails with an
+    /// error if the machine has no IPv6 connectivity.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ftr::Ftr;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let ftr = Ftr::new();
+    ///     let public_ipv6 = ftr.get_public_ip_v6().await?;
+    ///     println!("Public IPv6: {}", public_ipv6);
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn get_public_ip_v6(
+        &self,
+    ) -> Result<std::net::Ipv6Addr, crate::public_ip::providers::PublicIpError> {
+        self.services.stun.get_public_ip_v6().await
+    }
+
+    /// Get the public IP addresses for both families in parallel
+    ///
+    /// Discovers the public IPv4 and IPv6 addresses concurrently via STUN
+    /// and never fails: a family without connectivity is `None` in the
+    /// returned [`PublicIps`](crate::public_ip::PublicIps).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ftr::Ftr;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let ftr = Ftr::new();
+    ///     let ips = ftr.get_public_ips().await;
+    ///     println!("IPv4: {:?}, IPv6: {:?}", ips.v4, ips.v6);
+    /// }
+    /// ```
+    pub async fn get_public_ips(&self) -> crate::public_ip::PublicIps {
+        self.services.stun.get_public_ips().await
     }
 
     /// Clear all caches across all services

--- a/src/public_ip/mod.rs
+++ b/src/public_ip/mod.rs
@@ -9,8 +9,10 @@ use crate::services::Services;
 use crate::traceroute::IspInfo;
 use std::net::IpAddr;
 
-pub use providers::{PublicIpError, PublicIpProvider, get_public_ip};
-pub use service::StunClient;
+pub use providers::{
+    PUBLIC_IP_V6_URLS, PublicIpError, PublicIpProvider, get_public_ip, get_public_ip_v6_https,
+};
+pub use service::{PublicIps, StunClient};
 pub use stun::StunError;
 
 /// Detect ISP information from public IP using STUN (fast path) with services
@@ -40,6 +42,27 @@ pub async fn detect_isp_stun_with_services(services: &Services) -> Result<IspInf
         name: asn_info.name,
         hostname,
     })
+}
+
+/// Detect ISP information for the IPv6 path using STUN (fast) with services
+///
+/// Discovers the public IPv6 address via STUN over UDPv6 (falling back to
+/// IPv6-only HTTPS endpoints), then enriches it with ASN (Team Cymru
+/// origin6 zone) and reverse DNS. Fails when the host has no IPv6
+/// connectivity.
+pub async fn detect_isp_v6_stun_with_services(
+    services: &Services,
+) -> Result<IspInfo, PublicIpError> {
+    // Try STUN first (much faster than HTTPS)
+    let public_ip = match services.stun.get_public_ip_v6().await {
+        Ok(ip) => IpAddr::V6(ip),
+        Err(_) => {
+            // Fall back to HTTPS if STUN fails
+            IpAddr::V6(get_public_ip_v6_https().await?)
+        }
+    };
+
+    detect_isp_from_ip_with_services(public_ip, services).await
 }
 
 /// Detect ISP with default services using STUN (fast)

--- a/src/public_ip/providers.rs
+++ b/src/public_ip/providers.rs
@@ -1,6 +1,6 @@
 //! Public IP providers
 
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 use std::time::Duration;
 
 /// Error type for public IP detection
@@ -75,16 +75,41 @@ impl PublicIpProvider {
     }
 }
 
+/// IPv6-only HTTPS public-IP endpoints, tried in order by
+/// [`get_public_ip_v6_https`].
+///
+/// These hostnames publish only AAAA records, which forces the connection
+/// (and therefore the reported source address) over IPv6. The dual-stack
+/// `api64.ipify.org` is deliberately absent: it may answer over IPv4.
+/// Both endpoints verified live on 2026-07-16 to return the same address
+/// as STUN over UDPv6 (see `examples/spike_stun6.rs`).
+pub const PUBLIC_IP_V6_URLS: &[&str] = &["https://api6.ipify.org", "https://ipv6.icanhazip.com"];
+
 /// Get public IP address from a specific provider
 pub async fn get_public_ip_from_provider(
     provider: PublicIpProvider,
     timeout: Duration,
 ) -> Result<IpAddr, PublicIpError> {
-    let url = provider.url().to_string();
+    fetch_ip_from_url(provider.url().to_string(), timeout).await
+}
 
+/// Fetch an IP address from an HTTPS plain-text "what is my IP" endpoint
+async fn fetch_ip_from_url(url: String, timeout: Duration) -> Result<IpAddr, PublicIpError> {
     let ip_str = tokio::task::spawn_blocking(move || {
+        // This crate builds ureq with default-features = false and only the
+        // "native-tls" feature (see Cargo.toml), but ureq 3's default TLS
+        // provider is Rustls — using it without the "rustls" feature panics
+        // at request time ("provider is Rustls but feature is not
+        // enabled"). Select the native-tls provider explicitly, per the
+        // ureq 3 docs (ureq-3.3.0/src/lib.rs "Rustls and Native TLS"
+        // section).
         let agent: ureq::Agent = ureq::Agent::config_builder()
             .timeout_global(Some(timeout))
+            .tls_config(
+                ureq::tls::TlsConfig::builder()
+                    .provider(ureq::tls::TlsProvider::NativeTls)
+                    .build(),
+            )
             .build()
             .into();
         let body = agent
@@ -131,6 +156,29 @@ pub async fn get_public_ip(preferred_provider: PublicIpProvider) -> Result<IpAdd
             Err(_) => {
                 // Continue to next provider
             }
+        }
+    }
+
+    Err(PublicIpError::AllProvidersFailed)
+}
+
+/// Get the public IPv6 address over HTTPS, trying the endpoints in
+/// [`PUBLIC_IP_V6_URLS`] in order
+///
+/// This is the HTTPS fallback for the STUN-based
+/// [`StunClient::get_public_ip_v6`](crate::public_ip::StunClient::get_public_ip_v6).
+/// Fails with [`PublicIpError::AllProvidersFailed`] when the host has no
+/// IPv6 connectivity.
+pub async fn get_public_ip_v6_https() -> Result<Ipv6Addr, PublicIpError> {
+    // Same per-attempt budget as the v4 get_public_ip path
+    let timeout = Duration::from_secs(5);
+
+    for url in PUBLIC_IP_V6_URLS {
+        match fetch_ip_from_url((*url).to_string(), timeout).await {
+            // The endpoints are v6-only so a v4 answer should be
+            // impossible; skip such an endpoint rather than mislabel it.
+            Ok(IpAddr::V6(v6)) => return Ok(v6),
+            Ok(IpAddr::V4(_)) | Err(_) => continue,
         }
     }
 

--- a/src/public_ip/providers.rs
+++ b/src/public_ip/providers.rs
@@ -271,18 +271,28 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout_handling() {
-        let very_short_timeout = Duration::from_millis(1);
-        let result =
-            get_public_ip_from_provider(PublicIpProvider::AwsCheckIp, very_short_timeout).await;
+        // Hermetic timeout test: a local listener that accepts connections
+        // but never responds guarantees the request cannot complete,
+        // regardless of network conditions or ureq's sub-millisecond timer
+        // behavior (a live 1ms-timeout variant of this test flaked on CI).
+        let listener =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
+        let port = listener
+            .local_addr()
+            .expect("local listener has an address")
+            .port();
+        // Keep the listener alive but never accept/respond.
+        let url = format!("http://127.0.0.1:{port}/");
 
-        assert!(result.is_err());
+        let result = fetch_ip_from_url(url, Duration::from_millis(100)).await;
 
-        let err = result.expect_err("1ms timeout should fail");
+        let err = result.expect_err("unresponsive endpoint must time out");
         assert!(
             matches!(err, PublicIpError::Timeout | PublicIpError::HttpError(_)),
             "Unexpected error type: {}",
             err
         );
+        drop(listener);
     }
 
     #[test]

--- a/src/public_ip/service.rs
+++ b/src/public_ip/service.rs
@@ -4,12 +4,60 @@
 //! abstracting away the server address caching implementation details.
 
 use super::PublicIpError;
-use super::stun::{STUN_SERVERS, StunError, get_public_ip_stun_with_servers_and_cache};
+use super::stun::{
+    STUN_SERVERS, StunError, StunFamily, get_public_ip_stun_family_with_servers_and_cache,
+    get_public_ip_stun_with_servers_and_cache,
+};
 use super::stun_cache::StunCache;
-use std::net::IpAddr;
+use serde::{Deserialize, Serialize};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
+
+/// Public IP addresses for both address families
+///
+/// Aggregate result of [`StunClient::get_public_ips`], which discovers both
+/// families in parallel with never-throws semantics (mirroring SwiftFTR's
+/// `getPublicIPs()`): a family that cannot be discovered — no connectivity
+/// for that family, all servers failed, or a timeout — is simply `None`.
+///
+/// # Examples
+///
+/// ```no_run
+/// use ftr::public_ip::StunClient;
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let stun = StunClient::new();
+///     let ips = stun.get_public_ips().await;
+///     match ips.v6 {
+///         Some(v6) => println!("Public IPv6: {v6}"),
+///         None => println!("No public IPv6 connectivity"),
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct PublicIps {
+    /// Public IPv4 address, if discoverable
+    pub v4: Option<Ipv4Addr>,
+    /// Public IPv6 address, if discoverable
+    pub v6: Option<Ipv6Addr>,
+}
+
+/// Map a low-level STUN error into the public-IP error type
+fn map_stun_error(e: StunError) -> PublicIpError {
+    match e {
+        StunError::Timeout => PublicIpError::Timeout,
+        StunError::IoError(err) => PublicIpError::HttpError(err.to_string()),
+        StunError::InvalidResponse => {
+            PublicIpError::ParseError("Invalid STUN response".to_string())
+        }
+        StunError::NoMappedAddress => {
+            PublicIpError::ParseError("No mapped address in STUN response".to_string())
+        }
+    }
+}
 
 /// STUN client for public IP detection
 ///
@@ -122,16 +170,73 @@ impl StunClient {
             self.verbose,
         )
         .await
-        .map_err(|e| match e {
-            StunError::Timeout => PublicIpError::Timeout,
-            StunError::IoError(err) => PublicIpError::HttpError(err.to_string()),
-            StunError::InvalidResponse => {
-                PublicIpError::ParseError("Invalid STUN response".to_string())
-            }
-            StunError::NoMappedAddress => {
-                PublicIpError::ParseError("No mapped address in STUN response".to_string())
-            }
-        })
+        .map_err(map_stun_error)
+    }
+
+    /// Get the public IPv4 address
+    ///
+    /// Like [`get_public_ip`](Self::get_public_ip) but contacts the STUN
+    /// servers over IPv4 only (via their A records), so the mapped address
+    /// is guaranteed to be the public IPv4 address.
+    pub async fn get_public_ip_v4(&self) -> Result<Ipv4Addr, PublicIpError> {
+        let ip = get_public_ip_stun_family_with_servers_and_cache(
+            &self.servers,
+            self.timeout,
+            &self.cache,
+            self.verbose,
+            StunFamily::V4,
+        )
+        .await
+        .map_err(map_stun_error)?;
+        match ip {
+            IpAddr::V4(v4) => Ok(v4),
+            // Unreachable in practice: the family filter rejects mismatches
+            IpAddr::V6(v6) => Err(PublicIpError::ParseError(format!(
+                "STUN IPv4 query returned IPv6 address {v6}"
+            ))),
+        }
+    }
+
+    /// Get the public IPv6 address
+    ///
+    /// Contacts the STUN servers over IPv6 only (via their AAAA records)
+    /// and returns the XOR-MAPPED-ADDRESS they report. Note that IPv6
+    /// rarely involves NAT, so this usually equals the host's own global
+    /// address — but it still confirms end-to-end v6 reachability and
+    /// detects NAT66/NPTv6 edge cases.
+    ///
+    /// Fails with an error if the host has no IPv6 connectivity.
+    pub async fn get_public_ip_v6(&self) -> Result<Ipv6Addr, PublicIpError> {
+        let ip = get_public_ip_stun_family_with_servers_and_cache(
+            &self.servers,
+            self.timeout,
+            &self.cache,
+            self.verbose,
+            StunFamily::V6,
+        )
+        .await
+        .map_err(map_stun_error)?;
+        match ip {
+            IpAddr::V6(v6) => Ok(v6),
+            // Unreachable in practice: the family filter rejects mismatches
+            IpAddr::V4(v4) => Err(PublicIpError::ParseError(format!(
+                "STUN IPv6 query returned IPv4 address {v4}"
+            ))),
+        }
+    }
+
+    /// Get the public IP addresses for both families in parallel
+    ///
+    /// Runs the IPv4 and IPv6 discoveries concurrently and never fails:
+    /// a family that cannot be discovered is `None` in the returned
+    /// [`PublicIps`]. On an IPv4-only network `v6` is `None`; on an
+    /// IPv6-only network `v4` is `None`.
+    pub async fn get_public_ips(&self) -> PublicIps {
+        let (v4, v6) = tokio::join!(self.get_public_ip_v4(), self.get_public_ip_v6());
+        PublicIps {
+            v4: v4.ok(),
+            v6: v6.ok(),
+        }
     }
 
     /// Get the list of configured STUN servers

--- a/src/public_ip/stun.rs
+++ b/src/public_ip/stun.rs
@@ -67,6 +67,38 @@ pub async fn get_public_ip_stun_with_cache(
     get_public_ip_stun_with_cache_and_verbose(server, timeout, cache, 0).await
 }
 
+/// Address-family filter for STUN queries.
+///
+/// Crate-internal: the public entry points are
+/// [`StunClient::get_public_ip_v4`](crate::public_ip::StunClient::get_public_ip_v4),
+/// [`StunClient::get_public_ip_v6`](crate::public_ip::StunClient::get_public_ip_v6),
+/// and [`StunClient::get_public_ips`](crate::public_ip::StunClient::get_public_ips).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StunFamily {
+    /// Query over IPv4 only (A records / v4 server addresses)
+    V4,
+    /// Query over IPv6 only (AAAA records / v6 server addresses)
+    V6,
+}
+
+impl StunFamily {
+    /// Whether a resolved server address belongs to this family
+    fn matches_server(self, addr: &SocketAddr) -> bool {
+        match self {
+            StunFamily::V4 => addr.is_ipv4(),
+            StunFamily::V6 => addr.is_ipv6(),
+        }
+    }
+
+    /// Whether a mapped address returned by the server belongs to this family
+    fn matches_ip(self, ip: &IpAddr) -> bool {
+        match self {
+            StunFamily::V4 => ip.is_ipv4(),
+            StunFamily::V6 => ip.is_ipv6(),
+        }
+    }
+}
+
 /// Get public IP using STUN protocol with injected cache and an explicit
 /// verbosity level (2+ prints per-server diagnostics to stderr)
 pub async fn get_public_ip_stun_with_cache_and_verbose(
@@ -74,6 +106,19 @@ pub async fn get_public_ip_stun_with_cache_and_verbose(
     timeout: Duration,
     cache: &Arc<RwLock<crate::public_ip::stun_cache::StunCache>>,
     verbose: u8,
+) -> Result<IpAddr, StunError> {
+    get_public_ip_stun_filtered(server, timeout, cache, verbose, None).await
+}
+
+/// Get public IP from one STUN server, optionally restricted to a single
+/// address family. With a family set, only server addresses of that family
+/// are contacted and a mapped address of the wrong family is rejected.
+async fn get_public_ip_stun_filtered(
+    server: &str,
+    timeout: Duration,
+    cache: &Arc<RwLock<crate::public_ip::stun_cache::StunCache>>,
+    verbose: u8,
+    family: Option<StunFamily>,
 ) -> Result<IpAddr, StunError> {
     if verbose >= 2 {
         eprintln!("[STUN] Attempting to contact STUN server: {}", server);
@@ -92,13 +137,32 @@ pub async fn get_public_ip_stun_with_cache_and_verbose(
         })?;
     drop(cache_read);
 
-    // Try each address until one works
+    // Try each address (of the requested family, if any) until one works
     for server_addr in server_addrs {
+        if let Some(family) = family {
+            if !family.matches_server(&server_addr) {
+                continue;
+            }
+        }
         if verbose >= 2 {
             eprintln!("[STUN] Trying {} (resolved from {})", server_addr, server);
         }
         match get_public_ip_stun_addr(server_addr, timeout).await {
             Ok(ip) => {
+                // Defense in depth: a server contacted over one family
+                // should map that family, but reject a mismatch rather
+                // than report e.g. a v4 address as the public IPv6.
+                if let Some(family) = family {
+                    if !family.matches_ip(&ip) {
+                        if verbose >= 2 {
+                            eprintln!(
+                                "[STUN] {} returned {} which is not the requested family; skipping",
+                                server_addr, ip
+                            );
+                        }
+                        continue;
+                    }
+                }
                 if verbose >= 2 {
                     eprintln!(
                         "[STUN] Successfully obtained public IP {} from {}",
@@ -127,8 +191,15 @@ async fn get_public_ip_stun_addr(
     server_addr: SocketAddr,
     timeout: Duration,
 ) -> Result<IpAddr, StunError> {
-    // Use tokio's async UDP socket
-    let socket = tokio::net::UdpSocket::bind("0.0.0.0:0").await?;
+    // Use tokio's async UDP socket, bound to the same address family as
+    // the server (a v4-bound socket cannot send to a v6 server and vice
+    // versa).
+    let bind_addr = if server_addr.is_ipv6() {
+        "[::]:0"
+    } else {
+        "0.0.0.0:0"
+    };
+    let socket = tokio::net::UdpSocket::bind(bind_addr).await?;
 
     // Build STUN Binding Request
     let request = build_binding_request();
@@ -183,6 +254,29 @@ pub async fn get_public_ip_stun_with_servers_and_cache(
     Err(StunError::Timeout)
 }
 
+/// Get the public IP for one address family using STUN, trying the provided
+/// servers in order (with injected cache).
+///
+/// Like [`get_public_ip_stun_with_servers_and_cache`] but restricted to a
+/// single address family: only server addresses of that family are
+/// contacted (e.g. AAAA-resolved addresses for [`StunFamily::V6`]), so the
+/// mapped address the server reports is the public address for that family.
+pub(crate) async fn get_public_ip_stun_family_with_servers_and_cache(
+    servers: &[String],
+    timeout: Duration,
+    cache: &Arc<RwLock<crate::public_ip::stun_cache::StunCache>>,
+    verbose: u8,
+    family: StunFamily,
+) -> Result<IpAddr, StunError> {
+    for server in servers {
+        match get_public_ip_stun_filtered(server, timeout, cache, verbose, Some(family)).await {
+            Ok(ip) => return Ok(ip),
+            Err(_) => continue, // Try next server
+        }
+    }
+    Err(StunError::Timeout)
+}
+
 /// Build a STUN Binding Request message
 fn build_binding_request() -> Vec<u8> {
     let mut request = Vec::with_capacity(20);
@@ -229,6 +323,13 @@ fn parse_stun_response(data: &[u8]) -> Result<IpAddr, StunError> {
         return Err(StunError::InvalidResponse);
     }
 
+    // Transaction ID (bytes 8..20 of the header): the response echoes the
+    // request's transaction ID, and RFC 5389 section 15.2 XORs the IPv6
+    // mapped-address bytes against magic cookie || transaction ID.
+    let transaction_id: [u8; 12] = data[8..20]
+        .try_into()
+        .expect("slice of a >=20-byte buffer is 12 bytes");
+
     // Parse attributes
     let msg_length = u16::from_be_bytes([data[2], data[3]]) as usize;
     let mut offset = 20; // Skip header
@@ -243,7 +344,10 @@ fn parse_stun_response(data: &[u8]) -> Result<IpAddr, StunError> {
 
         match attr_type {
             XOR_MAPPED_ADDRESS if attr_length >= 8 => {
-                return parse_xor_mapped_address(&data[offset + 4..offset + 4 + attr_length]);
+                return parse_xor_mapped_address(
+                    &data[offset + 4..offset + 4 + attr_length],
+                    &transaction_id,
+                );
             }
             MAPPED_ADDRESS if attr_length >= 8 => {
                 // Legacy MAPPED-ADDRESS
@@ -259,8 +363,14 @@ fn parse_stun_response(data: &[u8]) -> Result<IpAddr, StunError> {
     Err(StunError::NoMappedAddress)
 }
 
-/// Parse XOR-MAPPED-ADDRESS attribute
-fn parse_xor_mapped_address(data: &[u8]) -> Result<IpAddr, StunError> {
+/// Parse XOR-MAPPED-ADDRESS attribute (RFC 5389 section 15.2)
+///
+/// The port is XORed with the most significant 16 bits of the magic
+/// cookie. IPv4 address bytes are XORed with the magic cookie; IPv6
+/// address bytes are XORed with the concatenation of the magic cookie and
+/// the transaction ID. Validated against live Google and Cloudflare STUN
+/// servers by `examples/spike_stun6.rs`.
+fn parse_xor_mapped_address(data: &[u8], transaction_id: &[u8; 12]) -> Result<IpAddr, StunError> {
     if data.len() < 8 {
         return Err(StunError::InvalidResponse);
     }
@@ -270,7 +380,7 @@ fn parse_xor_mapped_address(data: &[u8]) -> Result<IpAddr, StunError> {
 
     match family {
         0x01 => {
-            // IPv4
+            // IPv4: 4 address bytes XORed with the magic cookie
             if data.len() < 8 {
                 return Err(StunError::InvalidResponse);
             }
@@ -283,14 +393,24 @@ fn parse_xor_mapped_address(data: &[u8]) -> Result<IpAddr, StunError> {
             Ok(IpAddr::V4(std::net::Ipv4Addr::from(addr_bytes)))
         }
         0x02 => {
-            // IPv6 - not implemented yet
-            Err(StunError::InvalidResponse)
+            // IPv6: 16 address bytes XORed with magic cookie || transaction ID
+            if data.len() < 20 {
+                return Err(StunError::InvalidResponse);
+            }
+            let mut key = [0u8; 16];
+            key[..4].copy_from_slice(&STUN_MAGIC_COOKIE.to_be_bytes());
+            key[4..].copy_from_slice(transaction_id);
+            let mut addr_bytes = [0u8; 16];
+            for (i, byte) in addr_bytes.iter_mut().enumerate() {
+                *byte = data[4 + i] ^ key[i];
+            }
+            Ok(IpAddr::V6(std::net::Ipv6Addr::from(addr_bytes)))
         }
         _ => Err(StunError::InvalidResponse),
     }
 }
 
-/// Parse legacy MAPPED-ADDRESS attribute
+/// Parse legacy MAPPED-ADDRESS attribute (RFC 5389 section 15.1, no XOR)
 fn parse_mapped_address(data: &[u8]) -> Result<IpAddr, StunError> {
     if data.len() < 8 {
         return Err(StunError::InvalidResponse);
@@ -303,6 +423,16 @@ fn parse_mapped_address(data: &[u8]) -> Result<IpAddr, StunError> {
             // IPv4
             let addr_bytes = [data[4], data[5], data[6], data[7]];
             Ok(IpAddr::V4(std::net::Ipv4Addr::from(addr_bytes)))
+        }
+        0x02 => {
+            // IPv6: 16 plain (non-XORed) address bytes
+            if data.len() < 20 {
+                return Err(StunError::InvalidResponse);
+            }
+            let addr_bytes: [u8; 16] = data[4..20]
+                .try_into()
+                .expect("length checked above: 16 bytes");
+            Ok(IpAddr::V6(std::net::Ipv6Addr::from(addr_bytes)))
         }
         _ => Err(StunError::InvalidResponse),
     }
@@ -328,6 +458,110 @@ mod tests {
             u32::from_be_bytes([request[4], request[5], request[6], request[7]]),
             STUN_MAGIC_COOKIE
         );
+    }
+
+    /// Build a synthetic Binding Success Response containing one attribute.
+    fn synthetic_response(transaction_id: &[u8; 12], attr_type: u16, attr_value: &[u8]) -> Vec<u8> {
+        let padded_len = attr_value.len().div_ceil(4) * 4;
+        let mut resp = Vec::new();
+        resp.extend_from_slice(&BINDING_SUCCESS_RESPONSE.to_be_bytes());
+        resp.extend_from_slice(&((4 + padded_len) as u16).to_be_bytes());
+        resp.extend_from_slice(&STUN_MAGIC_COOKIE.to_be_bytes());
+        resp.extend_from_slice(transaction_id);
+        resp.extend_from_slice(&attr_type.to_be_bytes());
+        resp.extend_from_slice(&(attr_value.len() as u16).to_be_bytes());
+        resp.extend_from_slice(attr_value);
+        resp.resize(resp.len() + padded_len - attr_value.len(), 0);
+        resp
+    }
+
+    #[test]
+    fn test_parse_xor_mapped_address_v6_synthetic() {
+        // Known transaction ID and known address; the XOR key is
+        // magic cookie || transaction ID (RFC 5389 section 15.2).
+        let transaction_id: [u8; 12] = [
+            0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6, 0x07, 0x18, 0x29, 0x3a, 0x4b, 0x5c,
+        ];
+        let addr: std::net::Ipv6Addr = "2001:5a8:4684:c00:41b1:1c86:aee8:e97"
+            .parse()
+            .expect("valid IPv6 literal");
+        let port: u16 = 52410;
+
+        let mut key = [0u8; 16];
+        key[..4].copy_from_slice(&STUN_MAGIC_COOKIE.to_be_bytes());
+        key[4..].copy_from_slice(&transaction_id);
+
+        // XOR-MAPPED-ADDRESS value: reserved, family, x-port, x-address
+        let mut value = vec![0u8, 0x02];
+        value.extend_from_slice(&(port ^ (STUN_MAGIC_COOKIE >> 16) as u16).to_be_bytes());
+        for (i, byte) in addr.octets().iter().enumerate() {
+            value.push(byte ^ key[i]);
+        }
+
+        let resp = synthetic_response(&transaction_id, XOR_MAPPED_ADDRESS, &value);
+        let parsed = parse_stun_response(&resp).expect("synthetic v6 response must parse");
+        assert_eq!(parsed, IpAddr::V6(addr));
+    }
+
+    #[test]
+    fn test_parse_xor_mapped_address_v6_wrong_transaction_id_garbles_address() {
+        // The un-XOR depends on the transaction ID: the same attribute
+        // bytes under a different transaction ID must NOT yield the
+        // original address (guards against ignoring the transaction ID).
+        let txid_a: [u8; 12] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        let txid_b: [u8; 12] = [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+        let addr: std::net::Ipv6Addr = "2001:4860:4860::8888".parse().expect("valid literal");
+
+        let mut key = [0u8; 16];
+        key[..4].copy_from_slice(&STUN_MAGIC_COOKIE.to_be_bytes());
+        key[4..].copy_from_slice(&txid_a);
+        let mut value = vec![0u8, 0x02, 0, 0];
+        for (i, byte) in addr.octets().iter().enumerate() {
+            value.push(byte ^ key[i]);
+        }
+
+        let resp = synthetic_response(&txid_b, XOR_MAPPED_ADDRESS, &value);
+        let parsed = parse_stun_response(&resp).expect("still parses structurally");
+        assert_ne!(parsed, IpAddr::V6(addr));
+    }
+
+    #[test]
+    fn test_parse_xor_mapped_address_v6_truncated() {
+        // Family 0x02 with only a v4-sized value must be rejected
+        let transaction_id = [0u8; 12];
+        let value = [0u8, 0x02, 0x12, 0x34, 1, 2, 3, 4];
+        let resp = synthetic_response(&transaction_id, XOR_MAPPED_ADDRESS, &value);
+        assert!(matches!(
+            parse_stun_response(&resp),
+            Err(StunError::InvalidResponse)
+        ));
+    }
+
+    #[test]
+    fn test_parse_mapped_address_v6_legacy() {
+        // Legacy MAPPED-ADDRESS carries the address without XOR
+        let transaction_id = [7u8; 12];
+        let addr: std::net::Ipv6Addr = "2606:4700::1111".parse().expect("valid literal");
+        let mut value = vec![0u8, 0x02, 0x0d, 0x96]; // port 3478, not XORed
+        value.extend_from_slice(&addr.octets());
+        let resp = synthetic_response(&transaction_id, MAPPED_ADDRESS, &value);
+        let parsed = parse_stun_response(&resp).expect("legacy v6 response must parse");
+        assert_eq!(parsed, IpAddr::V6(addr));
+    }
+
+    #[test]
+    fn test_parse_xor_mapped_address_v4_still_works() {
+        // Regression guard: the v4 un-XOR path is unchanged
+        let transaction_id: [u8; 12] = [9u8; 12];
+        let addr: std::net::Ipv4Addr = "203.0.113.7".parse().expect("valid literal");
+        let cookie = STUN_MAGIC_COOKIE.to_be_bytes();
+        let mut value = vec![0u8, 0x01, 0, 0];
+        for (i, byte) in addr.octets().iter().enumerate() {
+            value.push(byte ^ cookie[i]);
+        }
+        let resp = synthetic_response(&transaction_id, XOR_MAPPED_ADDRESS, &value);
+        let parsed = parse_stun_response(&resp).expect("v4 response must parse");
+        assert_eq!(parsed, IpAddr::V4(addr));
     }
 
     #[tokio::test]

--- a/tests/ipv6_enrichment_test.rs
+++ b/tests/ipv6_enrichment_test.rs
@@ -1,0 +1,137 @@
+//! Live integration tests for IPv6 enrichment: Team Cymru origin6 ASN
+//! lookup and STUN-over-UDPv6 public IP detection.
+//!
+//! These tests require real dual-stack IPv6 connectivity and are gated
+//! behind `FTR_TEST_IPV6=1` so CI runners without IPv6 skip them:
+//!
+//! ```bash
+//! FTR_TEST_IPV6=1 cargo test --test ipv6_enrichment_test -- --nocapture
+//! ```
+
+use ftr::Ftr;
+use std::net::{IpAddr, Ipv6Addr};
+
+/// Returns true (and prints a notice) when live IPv6 tests are not enabled.
+fn skip_unless_ipv6_enabled(test_name: &str) -> bool {
+    if std::env::var("FTR_TEST_IPV6").is_err() {
+        eprintln!("{test_name}: skipped (set FTR_TEST_IPV6=1 to run live IPv6 tests)");
+        return true;
+    }
+    false
+}
+
+#[tokio::test]
+async fn test_live_asn_lookup_v6_google_dns() {
+    if skip_unless_ipv6_enabled("test_live_asn_lookup_v6_google_dns") {
+        return;
+    }
+
+    let ftr = Ftr::new();
+    let ip: IpAddr = "2001:4860:4860::8888".parse().expect("valid IP");
+    let info = ftr
+        .lookup_asn(ip)
+        .await
+        .expect("origin6 lookup for Google DNS should succeed");
+
+    eprintln!(
+        "2001:4860:4860::8888 => AS{} {} ({} / {} / {})",
+        info.asn, info.name, info.prefix, info.country_code, info.registry
+    );
+    assert_eq!(info.asn, 15169, "Google DNS v6 should be AS15169");
+    assert!(
+        info.name.contains("GOOGLE"),
+        "AS name should contain GOOGLE, got '{}'",
+        info.name
+    );
+    assert_eq!(info.prefix, "2001:4860::/32");
+}
+
+#[tokio::test]
+async fn test_live_asn_lookup_v6_own_public_ip() {
+    if skip_unless_ipv6_enabled("test_live_asn_lookup_v6_own_public_ip") {
+        return;
+    }
+
+    let ftr = Ftr::new();
+    let public_v6 = ftr
+        .get_public_ip_v6()
+        .await
+        .expect("machine should have public IPv6 (FTR_TEST_IPV6 is set)");
+
+    let info = ftr
+        .lookup_asn(IpAddr::V6(public_v6))
+        .await
+        .expect("ASN lookup of own public IPv6 should succeed");
+
+    eprintln!(
+        "own public IPv6 {public_v6} => AS{} {}",
+        info.asn, info.name
+    );
+    assert_ne!(info.asn, 0, "own public IPv6 should map to a real ASN");
+    assert!(!info.name.is_empty(), "AS name should be populated");
+}
+
+#[tokio::test]
+async fn test_live_stun_v6_matches_https_v6() {
+    if skip_unless_ipv6_enabled("test_live_stun_v6_matches_https_v6") {
+        return;
+    }
+
+    // STUN over UDPv6 and an independent v6-only HTTPS endpoint must agree
+    // on the public IPv6 address.
+    let ftr = Ftr::new();
+    let stun_v6: Ipv6Addr = ftr
+        .get_public_ip_v6()
+        .await
+        .expect("STUN v6 should succeed on a dual-stack network");
+    let https_v6 = ftr::public_ip::get_public_ip_v6_https()
+        .await
+        .expect("HTTPS v6 endpoint should succeed on a dual-stack network");
+
+    eprintln!("STUN v6: {stun_v6}, HTTPS v6: {https_v6}");
+    assert_eq!(
+        stun_v6, https_v6,
+        "STUN and HTTPS must report the same public IPv6"
+    );
+}
+
+#[tokio::test]
+async fn test_live_get_public_ips_both_families() {
+    if skip_unless_ipv6_enabled("test_live_get_public_ips_both_families") {
+        return;
+    }
+
+    let ftr = Ftr::new();
+    let ips = ftr.get_public_ips().await;
+    eprintln!("public IPs: v4={:?} v6={:?}", ips.v4, ips.v6);
+
+    // Dual-stack machine (FTR_TEST_IPV6 asserts v6 works): both present.
+    assert!(ips.v4.is_some(), "dual-stack machine should have public v4");
+    assert!(ips.v6.is_some(), "dual-stack machine should have public v6");
+    let v6 = ips.v6.expect("checked above");
+    assert!(!v6.is_loopback());
+    // A STUN-mapped v6 should be a global unicast, not link-local/ULA
+    let seg = v6.segments();
+    assert_ne!(seg[0] & 0xffc0, 0xfe80, "must not be link-local");
+    assert_ne!(seg[0] & 0xfe00, 0xfc00, "must not be unique-local");
+}
+
+#[tokio::test]
+async fn test_live_detect_isp_v6() {
+    if skip_unless_ipv6_enabled("test_live_detect_isp_v6") {
+        return;
+    }
+
+    let services = ftr::services::Services::new();
+    let isp = ftr::public_ip::detect_isp_v6_stun_with_services(&services)
+        .await
+        .expect("v6 ISP detection should succeed on a dual-stack network");
+
+    eprintln!(
+        "v6 ISP: {} (AS{}) public_ip={} hostname={:?}",
+        isp.name, isp.asn, isp.public_ip, isp.hostname
+    );
+    assert!(isp.public_ip.is_ipv6(), "public_ip must be an IPv6 address");
+    assert_ne!(isp.asn, 0, "ISP ASN should be a real ASN");
+    assert!(!isp.name.is_empty(), "ISP name should be populated");
+}


### PR DESCRIPTION
## Summary

Implements the enrichment half of IPv6 support ([#22](https://github.com/dweekly/ftr/issues/22), design in `docs/IPV6_DESIGN.md`): ASN lookup via Team Cymru's `origin6` zone and public-IPv6 detection via STUN, plus a v6 ISP-detection path. All public API changes are **additive**; no existing signatures changed. The v6 traceroute engine (sockets/probing) lands separately.

## What's new

### IPv6 ASN lookup (`src/asn/`)
- `AsnLookup::lookup(IpAddr::V6(..))` now works (previously returned `NotFound`): the full 32-nibble expanded address is nibble-reversed into an `origin6.asn.cymru.com` TXT query (construction proven by `examples/spike_asn6.rs`), parsed by the same Cymru payload parser as v4 (now shared helpers).
- Non-routable v6 short-circuits offline with the typed `asn=0` outcome matching v4's RFC 1918 handling: `::1`, `::`, `fe80::/10`, `fc00::/7`, `2001:db8::/32`, `ff00::/8`. v4-mapped `::ffff:0:0/96` defers to the v4 path for the embedded address.
- `AsnCache` gains `get_ipv6`/`insert_ipv6`; longest-prefix matching over v6 prefixes (e.g. `2001:4860::/32` answers for `2001:4860:4860::8888`) covered by unit tests.
- Additive: `AsnLookup::lookup_ipv6`, `AsnLookup::is_cached_ip`.
- Bonus fix in the shared parser: multi-origin payloads (`"15169 36040 | ..."`) now yield the first ASN instead of 0.

### STUN v6 (`src/public_ip/`)
- XOR-MAPPED-ADDRESS family 0x02 implemented per RFC 5389 §15.2 (port vs magic-cookie high bits; 16 address bytes vs magic cookie ‖ transaction ID — reference implementation `examples/spike_stun6.rs`); legacy MAPPED-ADDRESS v6 too. Client socket binds per server address family.
- Additive API:
  - `StunClient::get_public_ip_v4() -> Ipv4Addr` / `get_public_ip_v6() -> Ipv6Addr` — family-pinned (only A/AAAA-resolved server addresses contacted)
  - `StunClient::get_public_ips() -> PublicIps { v4: Option<Ipv4Addr>, v6: Option<Ipv6Addr> }` — both families in parallel, never-throws (SwiftFTR `getPublicIPs()` semantics)
  - `Ftr::get_public_ip_v6()`, `Ftr::get_public_ips()`
- Synthetic-buffer unit tests: known transaction ID → known address, wrong-txid garbling guard, truncated-value rejection, v4 regression guard.

### IPv6 ISP detection
- `detect_isp_v6_stun_with_services()`: STUN v6 → HTTPS v6 fallback → ASN + rDNS enrichment through the existing `IpAddr` path.
- `PUBLIC_IP_V6_URLS` (`api6.ipify.org`, `ipv6.icanhazip.com`) — AAAA-only hostnames so the connection is forced over v6; dual-stack `api64.ipify.org` deliberately excluded.

### Latent bug fixed
The HTTPS provider path panicked at runtime on **every** request: ureq 3 defaults to the Rustls TLS provider but this crate enables only `native-tls` (`"uri scheme is https, provider is Rustls but feature is not enabled: rustls"`). The agent now selects `TlsProvider::NativeTls` explicitly (ureq 3 docs, `src/lib.rs` "Rustls and Native TLS"). All three pre-existing v4 providers verified working again.

## Live evidence (dual-stack macOS, Sonic fiber, 2026-07-16)

`FTR_TEST_IPV6=1 cargo test --test ipv6_enrichment_test -- --nocapture`:

```
public IPs: v4=Some(192.184.164.83) v6=Some(2001:5a8:4681:2c00:e1a4:c4aa:953:f0fb)
test test_live_get_public_ips_both_families ... ok
2001:4860:4860::8888 => AS15169 GOOGLE - Google LLC (2001:4860::/32 / US / arin)
test test_live_asn_lookup_v6_google_dns ... ok
own public IPv6 2001:5a8:4681:2c00:e1a4:c4aa:953:f0fb => AS46375 AS-SONICTELECOM - Sonic Telecom LLC
test test_live_asn_lookup_v6_own_public_ip ... ok
v6 ISP: AS-SONICTELECOM - Sonic Telecom LLC (AS46375) public_ip=2001:5a8:4681:2c00:e1a4:c4aa:953:f0fb hostname=None
test test_live_detect_isp_v6 ... ok
STUN v6: 2001:5a8:4681:2c00:e1a4:c4aa:953:f0fb, HTTPS v6: 2001:5a8:4681:2c00:e1a4:c4aa:953:f0fb
test test_live_stun_v6_matches_https_v6 ... ok
test result: ok. 5 passed; 0 failed
```

Independent cross-check on the same machine: `curl -6 -s https://api64.ipify.org` → `2001:5a8:4681:2c00:e1a4:c4aa:953:f0fb` (matches STUN exactly).

## Validation

- `cargo fmt -- --check` clean
- `cargo clippy --all-targets --keep-going -- -D warnings` clean
- `cargo test`: 344 passed, 0 failed across all binaries (live v6 tests additionally pass with `FTR_TEST_IPV6=1`)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` clean
- `cargo check --target x86_64-pc-windows-msvc` clean (13 pre-existing dead-code warnings in `src/socket/icmp.rs`, untouched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
