### PR TITLE
feat: IPv6 traceroute support (ICMPv6 codec + macOS, family selection)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **ftr** (Fast TRaceroute) is a high-performance parallel ICMP traceroute written in Rust. It sends probes concurrently for ~10x speedup over traditional traceroute, with automatic ASN lookup, reverse DNS, public IP detection via STUN, and network segment classification. Available as both a CLI tool and a Rust library. Cross-platform: Linux, macOS, Windows, FreeBSD, OpenBSD.
 
-- **Version**: 0.8.0 (keep in sync with `Cargo.toml`)
+- **Version**: 0.9.0 (keep in sync with `Cargo.toml`)
 - **MSRV**: 1.85.0 (keep in sync with `rust-version` in `Cargo.toml`)
 - **Rust Edition**: 2024
 - **License**: MIT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "ftr"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftr"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 authors = ["David Weekly <david@weekly.org>"]
 description = "A fast, parallel ICMP traceroute with ASN lookup, reverse DNS, and ISP detection"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,11 +73,11 @@ criterion = { version = "0.7", features = ["html_reports"] }
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
 libc = "0.2"
 
-# libc on macOS is used ONLY by the IPv6 validation spikes in examples/
-# (recvmsg cmsg parsing for IPV6_HOPLIMIT, ICMP6_FILTER setsockopt) —
-# see docs/IPV6_DESIGN.md. It is a dev-dependency so the shipped library
-# and binary are unaffected.
-[target.'cfg(target_os = "macos")'.dev-dependencies]
+# libc on macOS is used by the ICMPv6 DGRAM receive path (recvmsg cmsg
+# parsing for IPV6_HOPLIMIT, ICMP6_FILTER setsockopt) — see
+# docs/IPV6_DESIGN.md — as well as by the IPv6 validation spikes in
+# examples/. Promoted from a dev-dependency when IPv6 traceroute landed.
+[target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"
 
 [lints.clippy]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,9 +145,9 @@ pub mod traceroute;
 // Re-export core types for library users
 pub use socket::{IpVersion, ProbeMode, ProbeProtocol, SocketMode};
 pub use traceroute::{
-    AsnInfo, ClassifiedHopInfo, ConfigError, IspInfo, RawHopInfo, SegmentType, TimingConfig,
-    Traceroute, TracerouteConfig, TracerouteConfigBuilder, TracerouteError, TracerouteProgress,
-    TracerouteResult, trace, trace_with_config,
+    AsnInfo, ClassifiedHopInfo, ConfigError, IspInfo, PreferredFamily, RawHopInfo, SegmentType,
+    TimingConfig, Traceroute, TracerouteConfig, TracerouteConfigBuilder, TracerouteError,
+    TracerouteProgress, TracerouteResult, resolve_target_with_family, trace, trace_with_config,
 };
 
 // Re-export API

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,10 @@
 #![allow(clippy::needless_pass_by_value)]
 
 use clap::Parser;
-use ftr::{ProbeProtocol, SocketMode, TracerouteConfigBuilder, TracerouteError, TracerouteResult};
+use ftr::{
+    PreferredFamily, ProbeProtocol, SocketMode, TracerouteConfigBuilder, TracerouteError,
+    TracerouteResult,
+};
 use std::net::IpAddr;
 use std::time::{Duration, Instant};
 
@@ -87,6 +90,30 @@ struct Args {
     /// Custom STUN server address (e.g., stun.l.google.com:19302)
     #[clap(long)]
     stun_server: Option<String>,
+
+    /// Force IPv4: only resolve the target to IPv4 addresses
+    #[clap(short = '4', long = "ipv4", conflicts_with = "force_ipv6")]
+    force_ipv4: bool,
+
+    /// Force IPv6: only resolve the target to IPv6 addresses
+    #[clap(short = '6', long = "ipv6")]
+    force_ipv6: bool,
+}
+
+impl Args {
+    /// Address family preference from the -4/-6 flags (clap enforces they
+    /// are mutually exclusive). Without either flag, Auto prefers IPv4 for
+    /// dual-stack hosts and uses IPv6 only for v6-only hosts — see
+    /// [`PreferredFamily`] for the rationale.
+    fn preferred_family(&self) -> PreferredFamily {
+        if self.force_ipv4 {
+            PreferredFamily::V4
+        } else if self.force_ipv6 {
+            PreferredFamily::V6
+        } else {
+            PreferredFamily::Auto
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
@@ -241,8 +268,10 @@ async fn async_main(_process_start: Instant) -> Result<(), Box<dyn std::error::E
         SocketModeArg::Dgram => SocketMode::Dgram,
     });
 
-    // Resolve target early to use in config
-    let target_ip = resolve_target(&args.host).await?;
+    // Resolve target early to use in config, honoring -4/-6
+    let target_ip = ftr::resolve_target_with_family(&args.host, args.preferred_family())
+        .await
+        .map_err(|e| format!("Error resolving host: {e}"))?;
 
     // Pre-fetch destination IP's rDNS and ASN lookups in the background
     {
@@ -284,6 +313,7 @@ async fn async_main(_process_start: Instant) -> Result<(), Box<dyn std::error::E
         .enable_asn_lookup(!args.no_enrich)
         .enable_rdns(!args.no_rdns)
         .verbose(args.verbose)
+        .preferred_family(args.preferred_family())
         .port(args.port);
 
     // Add public IP if provided
@@ -380,8 +410,11 @@ async fn async_main(_process_start: Instant) -> Result<(), Box<dyn std::error::E
             std::process::exit(1);
         }
         Err(TracerouteError::Ipv6NotSupported) => {
-            eprintln!("\nError: IPv6 targets are not yet supported");
-            eprintln!("Please use an IPv4 address or hostname that resolves to IPv4.");
+            eprintln!(
+                "\nError: IPv6 traceroute is not yet supported on {}",
+                std::env::consts::OS
+            );
+            eprintln!("Use an IPv4 target (or -4 to force IPv4 resolution).");
             std::process::exit(1);
         }
         Err(TracerouteError::ResolutionError(msg)) => {
@@ -409,26 +442,6 @@ async fn async_main(_process_start: Instant) -> Result<(), Box<dyn std::error::E
 
     // Quick exit to avoid cleanup overhead on Windows
     std::process::exit(0);
-}
-
-/// Resolve target hostname to IP address
-async fn resolve_target(host: &str) -> Result<IpAddr, Box<dyn std::error::Error>> {
-    // Try parsing as IP first
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        return Ok(ip);
-    }
-
-    // Handle localhost without DNS
-    if host == "localhost" {
-        return Ok(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
-    }
-
-    // Use our DNS resolver
-    let addrs = ftr::dns::resolve_a(host)
-        .await
-        .map_err(|e| format!("Error resolving host: {e}"))?;
-
-    Ok(IpAddr::V4(addrs[0]))
 }
 
 /// Display results in JSON format

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -22,13 +22,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_target_ip_address() {
+        use ftr::PreferredFamily;
+
         // Test with IPv4 address
-        let result = resolve_target("8.8.8.8").await;
+        let result = ftr::resolve_target_with_family("8.8.8.8", PreferredFamily::Auto).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "8.8.8.8".parse::<IpAddr>().unwrap());
 
         // Test with IPv6 address
-        let result = resolve_target("::1").await;
+        let result = ftr::resolve_target_with_family("::1", PreferredFamily::Auto).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "::1".parse::<IpAddr>().unwrap());
     }
@@ -36,7 +38,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_target_hostname() {
         // Test with localhost
-        let result = resolve_target("localhost").await;
+        let result = ftr::resolve_target_with_family("localhost", ftr::PreferredFamily::Auto).await;
         assert!(result.is_ok());
         let ip = result.unwrap();
         assert!(ip.is_loopback());
@@ -44,14 +46,41 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_target_invalid() {
-        let result = resolve_target("this.domain.definitely.does.not.exist.invalid").await;
+        let result = ftr::resolve_target_with_family(
+            "this.domain.definitely.does.not.exist.invalid",
+            ftr::PreferredFamily::Auto,
+        )
+        .await;
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Error resolving host")
-        );
+        assert!(matches!(
+            result.unwrap_err(),
+            ftr::TracerouteError::ResolutionError(_)
+        ));
+    }
+
+    #[test]
+    fn test_family_flags_parsing() {
+        use ftr::PreferredFamily;
+
+        // No flag: Auto
+        let args = Args::parse_from(["ftr", "google.com"]);
+        assert_eq!(args.preferred_family(), PreferredFamily::Auto);
+
+        // -4 forces IPv4 (short and long forms)
+        let args = Args::parse_from(["ftr", "-4", "google.com"]);
+        assert_eq!(args.preferred_family(), PreferredFamily::V4);
+        let args = Args::parse_from(["ftr", "--ipv4", "google.com"]);
+        assert_eq!(args.preferred_family(), PreferredFamily::V4);
+
+        // -6 forces IPv6 (short and long forms)
+        let args = Args::parse_from(["ftr", "-6", "google.com"]);
+        assert_eq!(args.preferred_family(), PreferredFamily::V6);
+        let args = Args::parse_from(["ftr", "--ipv6", "google.com"]);
+        assert_eq!(args.preferred_family(), PreferredFamily::V6);
+
+        // -4 and -6 conflict
+        let result = Args::try_parse_from(["ftr", "-4", "-6", "google.com"]);
+        assert!(result.is_err(), "-4 and -6 must be mutually exclusive");
     }
 
     #[test]

--- a/src/socket/factory.rs
+++ b/src/socket/factory.rs
@@ -136,6 +136,36 @@ pub async fn create_probe_socket_with_options_and_verbose(
                 ))
             }
         }
-        IpAddr::V6(_) => Err(TracerouteError::Ipv6NotSupported),
+        IpAddr::V6(_) => {
+            // Explicit UDP was requested but only ICMPv6 probing exists so far.
+            if let Some(ProbeProtocol::Udp) = protocol {
+                return Err(TracerouteError::NotImplemented {
+                    feature: "UDP IPv6 traceroute".to_string(),
+                });
+            }
+
+            #[cfg(target_os = "macos")]
+            {
+                let _ = socket_mode;
+                use super::macos_v6::MacOSAsyncIcmpV6Socket;
+                let socket =
+                    MacOSAsyncIcmpV6Socket::new_with_config_and_verbose(timing_config, verbose)?;
+
+                if verbose > 0 {
+                    eprintln!("Using DGRAM ICMPv6 mode for traceroute (per-probe version)");
+                }
+
+                Ok(Box::new(socket))
+            }
+
+            // Linux/Windows/BSD IPv6 probing is planned (see
+            // docs/IPV6_DESIGN.md open questions); until each platform's
+            // behavior is spike-validated, report the typed error.
+            #[cfg(not(target_os = "macos"))]
+            {
+                let _ = (timing_config, socket_mode, verbose);
+                Err(TracerouteError::Ipv6NotSupported)
+            }
+        }
     }
 }

--- a/src/socket/icmpv6.rs
+++ b/src/socket/icmpv6.rs
@@ -1,0 +1,465 @@
+//! Manual ICMPv6 packet construction and parsing
+//!
+//! Companion to [`super::icmp`] for IPv6 traceroute. All formats follow
+//! RFC 4443 (ICMPv6) and RFC 8200 (IPv6 header). Two deliberate differences
+//! from the IPv4 codec, both validated live in `docs/IPV6_DESIGN.md`:
+//!
+//! 1. **Checksum is left zero on send.** The ICMPv6 checksum covers the IPv6
+//!    pseudo-header (RFC 4443 section 2.3), whose source address userspace
+//!    may not know before send; the kernel fills it in on DGRAM ICMPv6
+//!    sockets (validated on macOS by `examples/spike_icmpv6_socket.rs`).
+//! 2. **Received buffers start at the ICMPv6 header.** Unlike IPv4 raw
+//!    sockets, the kernel never prepends the IPv6 header (RFC 3542 section
+//!    2.6 behavior, validated by the same spike), so there is no
+//!    variable-length IP header to skip.
+
+use std::net::Ipv6Addr;
+
+// ICMPv6 type constants (RFC 4443)
+/// ICMPv6 Destination Unreachable (type 1, RFC 4443 section 3.1)
+pub const ICMPV6_DEST_UNREACHABLE: u8 = 1;
+/// ICMPv6 Time Exceeded (type 3, RFC 4443 section 3.3)
+pub const ICMPV6_TIME_EXCEEDED: u8 = 3;
+/// ICMPv6 Echo Request (type 128, RFC 4443 section 4.1)
+pub const ICMPV6_ECHO_REQUEST: u8 = 128;
+/// ICMPv6 Echo Reply (type 129, RFC 4443 section 4.2)
+pub const ICMPV6_ECHO_REPLY: u8 = 129;
+
+/// ICMPv6 header size in bytes: type(1) + code(1) + checksum(2) +
+/// message-specific(4) — for echo, the 4 bytes are identifier + sequence
+/// (RFC 4443 section 2.1).
+pub const ICMPV6_HEADER_SIZE: usize = 8;
+
+/// IPv6 header size in bytes — fixed, no options/IHL (RFC 8200 section 3).
+pub const IPV6_HEADER_SIZE: usize = 40;
+
+/// IPv6 Next Header value for ICMPv6 (RFC 8200 / IANA protocol number 58).
+pub const IPV6_NEXT_HEADER_ICMPV6: u8 = 58;
+
+/// Minimum length of an ICMPv6 error message that embeds one of our echo
+/// probes: 8-byte error header + 40-byte invoking IPv6 header + 8-byte
+/// invoking ICMPv6 echo header (RFC 4443 section 3.3 layout, validated by
+/// `examples/spike_traceroute6.rs`).
+const MIN_ERROR_WITH_ECHO_LEN: usize = ICMPV6_HEADER_SIZE + IPV6_HEADER_SIZE + ICMPV6_HEADER_SIZE;
+
+/// Build an ICMPv6 Echo Request packet.
+///
+/// Layout: [type(1), code(1), checksum(2), identifier(2), sequence(2),
+/// payload(N)]. The checksum is deliberately left as zero: on DGRAM ICMPv6
+/// sockets the kernel computes it (it requires the IPv6 pseudo-header, which
+/// only the kernel knows at send time). Do NOT use this for a hypothetical
+/// send path where the kernel does not checksum.
+pub fn build_echo_request_v6(identifier: u16, sequence: u16, payload: &[u8]) -> Vec<u8> {
+    let mut buf = vec![0u8; ICMPV6_HEADER_SIZE + payload.len()];
+    buf[0] = ICMPV6_ECHO_REQUEST; // type
+    buf[1] = 0; // code
+    // checksum at [2..4] stays zero — kernel fills it in on DGRAM send
+    buf[4..6].copy_from_slice(&identifier.to_be_bytes());
+    buf[6..8].copy_from_slice(&sequence.to_be_bytes());
+    buf[ICMPV6_HEADER_SIZE..].copy_from_slice(payload);
+    buf
+}
+
+/// Parsed ICMPv6 header fields (type and code).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Icmpv6Header {
+    /// ICMPv6 message type
+    pub icmpv6_type: u8,
+    /// ICMPv6 message code
+    pub icmpv6_code: u8,
+}
+
+/// Parse the type and code from an ICMPv6 packet (buffer starting at the
+/// ICMPv6 header — no IPv6 header prefix on DGRAM/raw ICMPv6 sockets).
+pub fn parse_icmpv6_header(data: &[u8]) -> Option<Icmpv6Header> {
+    if data.len() < 4 {
+        return None;
+    }
+    Some(Icmpv6Header {
+        icmpv6_type: data[0],
+        icmpv6_code: data[1],
+    })
+}
+
+/// Extract identifier and sequence number from an ICMPv6 Echo Reply.
+///
+/// Returns `None` if the buffer is too short or is not an Echo Reply.
+/// The caller MUST validate the identifier against its own: Darwin delivers
+/// every inbound ICMPv6 packet to every DGRAM ICMPv6 socket (no kernel
+/// demux by echo identifier — validated finding in `docs/IPV6_DESIGN.md`).
+pub fn parse_echo_reply_v6(data: &[u8]) -> Option<(u16, u16)> {
+    if data.len() < ICMPV6_HEADER_SIZE || data[0] != ICMPV6_ECHO_REPLY {
+        return None;
+    }
+    let identifier = u16::from_be_bytes([data[4], data[5]]);
+    let sequence = u16::from_be_bytes([data[6], data[7]]);
+    Some((identifier, sequence))
+}
+
+/// The invoking echo probe recovered from an ICMPv6 error message
+/// (Time Exceeded or Destination Unreachable).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EmbeddedProbe {
+    /// Identifier of the invoking Echo Request
+    pub identifier: u16,
+    /// Sequence number of the invoking Echo Request
+    pub sequence: u16,
+    /// Destination the invoking packet was sent to (from the embedded IPv6
+    /// header) — lets callers confirm the error refers to their probe's
+    /// target, not another flow with a colliding id/seq.
+    pub destination: Ipv6Addr,
+}
+
+/// Parse the embedded invoking probe out of an ICMPv6 error message.
+///
+/// Layout (RFC 4443 section 3.3, validated live): 8-byte ICMPv6 error
+/// header, then as much of the invoking packet as fits — for our echo
+/// probes that is the fixed 40-byte invoking IPv6 header followed by the
+/// 8-byte invoking ICMPv6 echo header.
+///
+/// Returns `None` unless every layer checks out: outer type is Time
+/// Exceeded or Destination Unreachable, embedded IP version is 6, embedded
+/// Next Header is ICMPv6 (58), and the embedded message is an Echo Request.
+/// As with echo replies, the caller MUST validate the embedded identifier
+/// (and sequence) against its own probes.
+pub fn parse_embedded_probe(data: &[u8]) -> Option<EmbeddedProbe> {
+    if data.len() < MIN_ERROR_WITH_ECHO_LEN {
+        return None;
+    }
+    let outer_type = data[0];
+    if outer_type != ICMPV6_TIME_EXCEEDED && outer_type != ICMPV6_DEST_UNREACHABLE {
+        return None;
+    }
+
+    // Embedded (invoking) IPv6 header at fixed offset 8.
+    let inner_ip = &data[ICMPV6_HEADER_SIZE..ICMPV6_HEADER_SIZE + IPV6_HEADER_SIZE];
+    if inner_ip[0] >> 4 != 6 {
+        return None; // version nibble must be 6
+    }
+    // Next Header at byte 6 of the IPv6 header (RFC 8200 section 3). We only
+    // ever send bare ICMPv6 echoes (no extension headers), so anything else
+    // is not our probe.
+    if inner_ip[6] != IPV6_NEXT_HEADER_ICMPV6 {
+        return None;
+    }
+    let destination = Ipv6Addr::from(<[u8; 16]>::try_from(&inner_ip[24..40]).ok()?);
+
+    // Embedded (invoking) ICMPv6 echo header at fixed offset 48.
+    let inner_icmp = &data[ICMPV6_HEADER_SIZE + IPV6_HEADER_SIZE..MIN_ERROR_WITH_ECHO_LEN];
+    if inner_icmp[0] != ICMPV6_ECHO_REQUEST {
+        return None;
+    }
+    Some(EmbeddedProbe {
+        identifier: u16::from_be_bytes([inner_icmp[4], inner_icmp[5]]),
+        sequence: u16::from_be_bytes([inner_icmp[6], inner_icmp[7]]),
+        destination,
+    })
+}
+
+/// Whether an ICMPv6 type is Neighbor Discovery / Router Discovery chatter
+/// (RFC 4861 types 133-137: RS, RA, NS, NA, Redirect).
+///
+/// A DGRAM ICMPv6 socket on Darwin receives this link noise interleaved
+/// with echo replies (observed live — see `docs/IPV6_DESIGN.md`); receive
+/// loops should skip these silently. An `ICMP6_FILTER` passing only types
+/// 1/3/129 sheds them in the kernel, but that filter is best-effort — this
+/// predicate keeps the userspace path correct regardless.
+pub fn is_ndp(icmpv6_type: u8) -> bool {
+    (133..=137).contains(&icmpv6_type)
+}
+
+/// Format an IPv6 address with its RFC 4007 zone identifier, if any.
+///
+/// The address itself renders through `Ipv6Addr`'s `Display`, which is
+/// RFC 5952 canonical (lowercase, longest zero run compressed to `::`) —
+/// never hand-format hextets. A non-zero scope id is appended as `%zone`.
+/// On Unix platforms with `libc` available the interface name is used
+/// (`fe80::1%en0`); otherwise, or if the index has no name, the numeric
+/// form (`fe80::1%5`) — both are valid RFC 4007 zone identifiers.
+pub fn format_ipv6_with_zone(addr: Ipv6Addr, scope_id: u32) -> String {
+    if scope_id == 0 {
+        return addr.to_string();
+    }
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "openbsd"
+    ))]
+    {
+        // IF_NAMESIZE-sized buffer per POSIX if_indextoname(3).
+        let mut name_buf = [0u8; libc::IF_NAMESIZE];
+        // SAFETY: name_buf is a valid, writable IF_NAMESIZE-byte buffer for
+        // the duration of the call, as if_indextoname requires.
+        let ret = unsafe { libc::if_indextoname(scope_id, name_buf.as_mut_ptr().cast()) };
+        if !ret.is_null() {
+            let len = name_buf.iter().position(|&b| b == 0).unwrap_or(0);
+            if let Ok(name) = std::str::from_utf8(&name_buf[..len]) {
+                if !name.is_empty() {
+                    return format!("{addr}%{name}");
+                }
+            }
+        }
+    }
+    format!("{addr}%{scope_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic ICMPv6 error message (Time Exceeded or Destination
+    /// Unreachable) embedding an invoking IPv6+ICMPv6 echo, mirroring what
+    /// routers send back (observed layout in docs/IPV6_DESIGN.md).
+    fn build_error_message(
+        outer_type: u8,
+        inner_version: u8,
+        inner_next_header: u8,
+        inner_icmp_type: u8,
+        identifier: u16,
+        sequence: u16,
+        dst: Ipv6Addr,
+    ) -> Vec<u8> {
+        let mut buf = vec![0u8; MIN_ERROR_WITH_ECHO_LEN];
+        buf[0] = outer_type;
+        // bytes 1..8: code, checksum, unused — zero is fine
+        let inner_ip = &mut buf[8..48];
+        inner_ip[0] = inner_version << 4;
+        inner_ip[6] = inner_next_header;
+        inner_ip[7] = 1; // hop limit decremented to 1, as routers report
+        // src (bytes 8..24) left zero; dst at 24..40
+        inner_ip[24..40].copy_from_slice(&dst.octets());
+        let inner_icmp = &mut buf[48..56];
+        inner_icmp[0] = inner_icmp_type;
+        inner_icmp[4..6].copy_from_slice(&identifier.to_be_bytes());
+        inner_icmp[6..8].copy_from_slice(&sequence.to_be_bytes());
+        buf
+    }
+
+    const GOOGLE_V6: Ipv6Addr = Ipv6Addr::new(0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888);
+
+    #[test]
+    fn test_build_echo_request_v6_layout() {
+        let pkt = build_echo_request_v6(0x1234, 0x0007, &[0xAA, 0xBB]);
+        assert_eq!(pkt.len(), 10);
+        assert_eq!(pkt[0], ICMPV6_ECHO_REQUEST);
+        assert_eq!(pkt[1], 0); // code
+        assert_eq!(&pkt[2..4], &[0, 0]); // checksum left for the kernel
+        assert_eq!(u16::from_be_bytes([pkt[4], pkt[5]]), 0x1234);
+        assert_eq!(u16::from_be_bytes([pkt[6], pkt[7]]), 0x0007);
+        assert_eq!(&pkt[8..], &[0xAA, 0xBB]);
+    }
+
+    #[test]
+    fn test_build_echo_request_v6_empty_payload() {
+        let pkt = build_echo_request_v6(1, 2, &[]);
+        assert_eq!(pkt.len(), ICMPV6_HEADER_SIZE);
+    }
+
+    #[test]
+    fn test_parse_icmpv6_header() {
+        let hdr = parse_icmpv6_header(&[ICMPV6_TIME_EXCEEDED, 0, 0xde, 0xad])
+            .expect("4-byte header should parse");
+        assert_eq!(hdr.icmpv6_type, ICMPV6_TIME_EXCEEDED);
+        assert_eq!(hdr.icmpv6_code, 0);
+        assert!(parse_icmpv6_header(&[1, 2, 3]).is_none()); // too short
+    }
+
+    #[test]
+    fn test_parse_echo_reply_v6() {
+        let mut data = vec![0u8; ICMPV6_HEADER_SIZE];
+        data[0] = ICMPV6_ECHO_REPLY;
+        data[4..6].copy_from_slice(&0xBEEFu16.to_be_bytes());
+        data[6..8].copy_from_slice(&42u16.to_be_bytes());
+        assert_eq!(parse_echo_reply_v6(&data), Some((0xBEEF, 42)));
+    }
+
+    #[test]
+    fn test_parse_echo_reply_v6_rejects_wrong_type_and_short() {
+        let mut data = vec![0u8; ICMPV6_HEADER_SIZE];
+        data[0] = ICMPV6_ECHO_REQUEST; // request, not reply
+        assert!(parse_echo_reply_v6(&data).is_none());
+        assert!(parse_echo_reply_v6(&[ICMPV6_ECHO_REPLY, 0, 0, 0]).is_none());
+    }
+
+    #[test]
+    fn test_parse_embedded_probe_time_exceeded() {
+        let msg = build_error_message(
+            ICMPV6_TIME_EXCEEDED,
+            6,
+            IPV6_NEXT_HEADER_ICMPV6,
+            ICMPV6_ECHO_REQUEST,
+            0x3333,
+            9,
+            GOOGLE_V6,
+        );
+        let probe = parse_embedded_probe(&msg).expect("valid TE should parse");
+        assert_eq!(probe.identifier, 0x3333);
+        assert_eq!(probe.sequence, 9);
+        assert_eq!(probe.destination, GOOGLE_V6);
+    }
+
+    #[test]
+    fn test_parse_embedded_probe_dest_unreachable() {
+        let msg = build_error_message(
+            ICMPV6_DEST_UNREACHABLE,
+            6,
+            IPV6_NEXT_HEADER_ICMPV6,
+            ICMPV6_ECHO_REQUEST,
+            7,
+            8,
+            GOOGLE_V6,
+        );
+        let probe = parse_embedded_probe(&msg).expect("valid unreachable should parse");
+        assert_eq!((probe.identifier, probe.sequence), (7, 8));
+    }
+
+    #[test]
+    fn test_parse_embedded_probe_rejects_echo_reply_outer_type() {
+        let msg = build_error_message(
+            ICMPV6_ECHO_REPLY, // not an error type
+            6,
+            IPV6_NEXT_HEADER_ICMPV6,
+            ICMPV6_ECHO_REQUEST,
+            1,
+            1,
+            GOOGLE_V6,
+        );
+        assert!(parse_embedded_probe(&msg).is_none());
+    }
+
+    #[test]
+    fn test_parse_embedded_probe_rejects_bad_version() {
+        let msg = build_error_message(
+            ICMPV6_TIME_EXCEEDED,
+            4, // embedded packet claims IPv4
+            IPV6_NEXT_HEADER_ICMPV6,
+            ICMPV6_ECHO_REQUEST,
+            1,
+            1,
+            GOOGLE_V6,
+        );
+        assert!(parse_embedded_probe(&msg).is_none());
+    }
+
+    #[test]
+    fn test_parse_embedded_probe_rejects_non_icmpv6_next_header() {
+        let msg = build_error_message(
+            ICMPV6_TIME_EXCEEDED,
+            6,
+            17, // UDP — some other tool's probe expired, not ours
+            ICMPV6_ECHO_REQUEST,
+            1,
+            1,
+            GOOGLE_V6,
+        );
+        assert!(parse_embedded_probe(&msg).is_none());
+    }
+
+    #[test]
+    fn test_parse_embedded_probe_rejects_non_echo_inner() {
+        let msg = build_error_message(
+            ICMPV6_TIME_EXCEEDED,
+            6,
+            IPV6_NEXT_HEADER_ICMPV6,
+            ICMPV6_ECHO_REPLY, // embedded packet is a reply, not our request
+            1,
+            1,
+            GOOGLE_V6,
+        );
+        assert!(parse_embedded_probe(&msg).is_none());
+    }
+
+    #[test]
+    fn test_parse_embedded_probe_rejects_truncated() {
+        let msg = build_error_message(
+            ICMPV6_TIME_EXCEEDED,
+            6,
+            IPV6_NEXT_HEADER_ICMPV6,
+            ICMPV6_ECHO_REQUEST,
+            1,
+            1,
+            GOOGLE_V6,
+        );
+        // One byte short of embedding the full echo header.
+        assert!(parse_embedded_probe(&msg[..MIN_ERROR_WITH_ECHO_LEN - 1]).is_none());
+    }
+
+    #[test]
+    fn test_is_ndp_covers_discovery_types_only() {
+        // RFC 4861: RS=133, RA=134, NS=135, NA=136, Redirect=137 — all seen
+        // live on a DGRAM ICMPv6 socket (docs/IPV6_DESIGN.md).
+        for ty in 133..=137u8 {
+            assert!(is_ndp(ty), "type {ty} is NDP");
+        }
+        for ty in [
+            ICMPV6_DEST_UNREACHABLE,
+            ICMPV6_TIME_EXCEEDED,
+            ICMPV6_ECHO_REQUEST,
+            ICMPV6_ECHO_REPLY,
+            132,
+            138,
+        ] {
+            assert!(!is_ndp(ty), "type {ty} is not NDP");
+        }
+    }
+
+    /// Address-contract test: Rust's `Ipv6Addr` `Display` must emit RFC 5952
+    /// canonical form (lowercase, longest zero run compressed to `::`) —
+    /// this is what ftr's design doc commits to for all v6 address strings.
+    #[test]
+    fn test_ipv6_display_is_rfc5952_canonical() {
+        let cases: [(Ipv6Addr, &str); 7] = [
+            (Ipv6Addr::UNSPECIFIED, "::"),
+            (Ipv6Addr::LOCALHOST, "::1"),
+            (GOOGLE_V6, "2001:4860:4860::8888"),
+            // Longest zero run compressed, not the first shorter one
+            (
+                Ipv6Addr::new(0x2001, 0xdb8, 0, 1, 0, 0, 0, 1),
+                "2001:db8:0:1::1",
+            ),
+            // Lowercase hex digits (RFC 5952 section 4.3)
+            (
+                Ipv6Addr::new(0x2001, 0xDB8, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF),
+                "2001:db8:a:b:c:d:e:f",
+            ),
+            // IPv4-mapped renders with dotted quad
+            (
+                Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0102, 0x0304),
+                "::ffff:1.2.3.4",
+            ),
+            // Single zero group is NOT compressed to :: (RFC 5952 4.2.2)
+            (
+                Ipv6Addr::new(0x2001, 0xdb8, 1, 1, 1, 1, 0, 1),
+                "2001:db8:1:1:1:1:0:1",
+            ),
+        ];
+        for (addr, want) in cases {
+            assert_eq!(addr.to_string(), want);
+            // And the canonical string round-trips.
+            assert_eq!(want.parse::<Ipv6Addr>().expect("round-trip parse"), addr);
+        }
+    }
+
+    #[test]
+    fn test_format_ipv6_with_zone() {
+        let ll = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+        // Zero scope id: plain canonical address, no % suffix.
+        assert_eq!(format_ipv6_with_zone(ll, 0), "fe80::1");
+        // Loopback interface index 1 exists on every Unix system; the zone
+        // must be appended (as a name like "lo0"/"lo" or numerically), never
+        // stripped.
+        let formatted = format_ipv6_with_zone(ll, 1);
+        let (addr_part, zone) = formatted
+            .split_once('%')
+            .expect("non-zero scope must render a %zone suffix");
+        assert_eq!(addr_part, "fe80::1");
+        assert!(!zone.is_empty());
+        // An index that cannot correspond to a real interface falls back to
+        // the numeric RFC 4007 zone form.
+        assert_eq!(
+            format_ipv6_with_zone(ll, 0x7fff_fff0),
+            format!("fe80::1%{}", 0x7fff_fff0)
+        );
+    }
+}

--- a/src/socket/macos_v6.rs
+++ b/src/socket/macos_v6.rs
@@ -1,0 +1,606 @@
+//! macOS async ICMPv6 socket using per-probe DGRAM sockets
+//!
+//! Unprivileged IPv6 traceroute: `Domain::IPV6`/`Type::DGRAM`/
+//! `Protocol::ICMPV6` sockets work without root on Darwin and receive
+//! ICMPv6 Time Exceeded from intermediate routers on the normal receive
+//! path — both validated live by `examples/spike_traceroute6.rs` (findings
+//! recorded in `docs/IPV6_DESIGN.md`). Mirrors the per-probe-socket design
+//! of the IPv4 implementation in [`super::macos`].
+//!
+//! Two Darwin-specific behaviors shape this module (both spike-proven):
+//!
+//! 1. **No kernel demux by echo identifier.** Every DGRAM ICMPv6 socket
+//!    receives ALL inbound ICMPv6 traffic — other processes' echo replies,
+//!    other probes from this same trace, and NDP/RA link noise. Userspace
+//!    identifier+sequence filtering is therefore mandatory for correctness,
+//!    on Echo Replies AND on the embedded probe inside error messages.
+//! 2. **`ICMP6_FILTER` works** (BSD semantics, bit set = PASS) and sheds the
+//!    NDP noise in the kernel, but it cannot distinguish two concurrent
+//!    traces' echoes, so it is applied strictly as an optimization: setup
+//!    failure is logged and ignored.
+
+use crate::TimingConfig;
+use crate::probe::{ProbeInfo, ProbeResponse};
+use crate::socket::icmpv6;
+use crate::socket::traits::{ProbeMode, ProbeSocket};
+use crate::traceroute::TracerouteError;
+use socket2::{Domain, Protocol, SockAddr, Socket as Socket2, Type};
+use std::future::Future;
+use std::net::{IpAddr, Ipv6Addr, SocketAddrV6};
+use std::os::fd::AsRawFd;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+/// Size of the ICMPv6 echo payload, matching the IPv4 implementation's
+/// [`super::macos`] probe payload size.
+const ICMPV6_ECHO_PAYLOAD_SIZE: usize = 16;
+
+/// Receive buffer size — a full Ethernet-MTU packet comfortably fits.
+const RECV_BUFFER_SIZE: usize = 1500;
+
+/// Polling interval while waiting for a reply on the non-blocking socket,
+/// matching the IPv4 macOS implementation's 1 ms poll loop.
+const RECV_POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+/// `ICMP6_FILTER` socket option (level `IPPROTO_ICMPV6`). The libc crate
+/// does not define it for Apple targets; the value 18 is verified against
+/// the macOS SDK header `netinet6/in6.h` line 392
+/// (`#define ICMP6_FILTER 18`) — same citation as the validation spike.
+const ICMP6_FILTER: libc::c_int = 18;
+
+/// Mirror of `struct icmp6_filter` (macOS SDK `netinet/icmp6.h` line 624):
+/// 256 bits, one per ICMPv6 type. BSD semantics: bit SET means PASS
+/// (`ICMP6_FILTER_SETPASS` ORs the bit in; `SETBLOCKALL` is memset 0).
+/// Linux inverts these semantics (bit = block) — do not reuse as-is there.
+#[repr(C)]
+struct Icmp6Filter {
+    icmp6_filt: [u32; 8],
+}
+
+impl Icmp6Filter {
+    /// Start from "block everything" (all bits clear).
+    fn block_all() -> Self {
+        Icmp6Filter { icmp6_filt: [0; 8] }
+    }
+
+    /// Set the PASS bit for one ICMPv6 type, mirroring the
+    /// `ICMP6_FILTER_SETPASS` macro: `filt[type >> 5] |= 1 << (type & 31)`.
+    fn pass(mut self, ty: u8) -> Self {
+        self.icmp6_filt[(ty >> 5) as usize] |= 1u32 << (ty & 31);
+        self
+    }
+}
+
+/// Monotonic per-process counter mixed into each socket's ICMP identifier.
+///
+/// Darwin does not demux ICMPv6 by identifier, so uniqueness is not about
+/// kernel routing — it lets concurrent traces in one process (and, with the
+/// PID component, across processes) tell their packets apart in userspace.
+/// Carried-over SwiftFTR lesson recorded in `docs/IPV6_DESIGN.md`.
+static NEXT_SESSION: AtomicU16 = AtomicU16::new(0);
+
+/// Derive a fresh ICMP identifier: low byte of the PID in the high bits,
+/// per-process session counter in the low bits.
+fn next_identifier() -> u16 {
+    let pid_component = (std::process::id() & 0xff) as u16;
+    let session = NEXT_SESSION.fetch_add(1, Ordering::Relaxed) & 0xff;
+    (pid_component << 8) | session
+}
+
+/// One received ICMPv6 packet plus recvmsg metadata.
+struct ReceivedV6 {
+    bytes_len: usize,
+    /// Sender, including the sin6_scope_id zone for link-local responders —
+    /// never stripped (address contract in `docs/IPV6_DESIGN.md`).
+    from: SocketAddrV6,
+    /// Hop limit of the received packet from the `IPV6_HOPLIMIT` cmsg
+    /// (requires `IPV6_RECVHOPLIMIT`; used for verbose diagnostics).
+    hop_limit: Option<u32>,
+}
+
+/// Receive one datagram with `libc::recvmsg` so the `IPV6_HOPLIMIT`
+/// ancillary data is readable (socket2 0.6 exposes `recvmsg` but no cmsg
+/// parser). Returns `Ok(None)` when the non-blocking socket has nothing
+/// pending (EAGAIN/EWOULDBLOCK).
+fn recvmsg_v6(socket: &Socket2, buf: &mut [u8]) -> std::io::Result<Option<ReceivedV6>> {
+    let mut name: libc::sockaddr_in6 = unsafe { std::mem::zeroed() };
+    // Space for a few cmsgs; CMSG_SPACE(4) is ~16 bytes on Darwin, 256 is
+    // comfortably enough (same sizing as the validation spike).
+    let mut control = [0u8; 256];
+    let mut iov = libc::iovec {
+        iov_base: buf.as_mut_ptr().cast(),
+        iov_len: buf.len(),
+    };
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_name = (&raw mut name).cast();
+    msg.msg_namelen = std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t;
+    msg.msg_iov = &raw mut iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = control.as_mut_ptr().cast();
+    msg.msg_controllen = control.len() as _;
+
+    // SAFETY: all msghdr pointers reference live stack buffers above.
+    let n = unsafe { libc::recvmsg(socket.as_raw_fd(), &raw mut msg, 0) };
+    if n < 0 {
+        let err = std::io::Error::last_os_error();
+        return if err.kind() == std::io::ErrorKind::WouldBlock {
+            Ok(None)
+        } else {
+            Err(err)
+        };
+    }
+
+    let mut hop_limit = None;
+    // SAFETY: cmsg iteration follows the CMSG_* contract on the msghdr that
+    // recvmsg just filled in.
+    unsafe {
+        let mut cmsg = libc::CMSG_FIRSTHDR(&raw const msg);
+        while !cmsg.is_null() {
+            if (*cmsg).cmsg_level == libc::IPPROTO_IPV6 && (*cmsg).cmsg_type == libc::IPV6_HOPLIMIT
+            {
+                let mut v: libc::c_int = 0;
+                std::ptr::copy_nonoverlapping(
+                    libc::CMSG_DATA(cmsg),
+                    (&raw mut v).cast::<u8>(),
+                    std::mem::size_of::<libc::c_int>(),
+                );
+                hop_limit = Some(v as u32);
+            }
+            cmsg = libc::CMSG_NXTHDR(&raw const msg, cmsg);
+        }
+    }
+
+    let from = SocketAddrV6::new(
+        Ipv6Addr::from(name.sin6_addr.s6_addr),
+        u16::from_be(name.sin6_port),
+        u32::from_be(name.sin6_flowinfo),
+        name.sin6_scope_id,
+    );
+    Ok(Some(ReceivedV6 {
+        bytes_len: n as usize,
+        from,
+        hop_limit,
+    }))
+}
+
+/// macOS async ICMPv6 socket implementation using per-probe DGRAM sockets.
+pub struct MacOSAsyncIcmpV6Socket {
+    icmp_identifier: u16,
+    destination_reached: Arc<AtomicBool>,
+    pending_count: Arc<AtomicUsize>,
+    timing_config: TimingConfig,
+    verbose: u8,
+}
+
+impl MacOSAsyncIcmpV6Socket {
+    /// Create a new macOS async ICMPv6 socket handle with timing
+    /// configuration and an explicit verbosity level.
+    pub fn new_with_config_and_verbose(
+        timing_config: TimingConfig,
+        verbose: u8,
+    ) -> Result<Self, TracerouteError> {
+        trace_time!(
+            verbose,
+            "Creating macOS async ICMPv6 socket (per-probe version)"
+        );
+
+        // Probe socket creation up front so permission/support problems
+        // surface as a typed error at setup time, not on the first probe.
+        Socket2::new(Domain::IPV6, Type::DGRAM, Some(Protocol::ICMPV6)).map_err(|e| {
+            TracerouteError::SocketError(format!("Failed to create ICMPv6 DGRAM socket: {e}"))
+        })?;
+
+        Ok(Self {
+            icmp_identifier: next_identifier(),
+            destination_reached: Arc::new(AtomicBool::new(false)),
+            pending_count: Arc::new(AtomicUsize::new(0)),
+            timing_config,
+            verbose,
+        })
+    }
+
+    /// Apply the traceroute `ICMP6_FILTER` (pass Destination Unreachable,
+    /// Time Exceeded, Echo Reply only) via raw setsockopt — socket2 exposes
+    /// no API for it (<https://github.com/rust-lang/socket2/issues/199>).
+    ///
+    /// Best-effort: kernel-side noise shedding only. Userspace identifier
+    /// filtering below is what guarantees correctness, so failure here is
+    /// logged (verbose) and otherwise ignored.
+    fn apply_icmp6_filter(&self, socket: &Socket2) {
+        let filter = Icmp6Filter::block_all()
+            .pass(icmpv6::ICMPV6_DEST_UNREACHABLE)
+            .pass(icmpv6::ICMPV6_TIME_EXCEEDED)
+            .pass(icmpv6::ICMPV6_ECHO_REPLY);
+        // SAFETY: fd is valid for the lifetime of `socket`; the buffer is a
+        // properly sized repr(C) mirror of struct icmp6_filter.
+        let rc = unsafe {
+            libc::setsockopt(
+                socket.as_raw_fd(),
+                libc::IPPROTO_ICMPV6,
+                ICMP6_FILTER,
+                (&raw const filter).cast(),
+                std::mem::size_of::<Icmp6Filter>() as libc::socklen_t,
+            )
+        };
+        if rc != 0 {
+            trace_time!(
+                self.verbose,
+                "setsockopt(ICMP6_FILTER) failed ({}); continuing with userspace filtering only",
+                std::io::Error::last_os_error()
+            );
+        }
+    }
+
+    /// Parse one received ICMPv6 packet (buffer starts AT the ICMPv6
+    /// header — no IPv6 header prefix) against this probe's id/seq.
+    ///
+    /// Returns `None` for anything that is not a definitive answer to this
+    /// probe: NDP noise, other sessions' echoes, other sequences from this
+    /// same trace. Skipping silently is correct — Darwin funnels all ICMPv6
+    /// to every DGRAM socket.
+    fn parse_response_v6(
+        &self,
+        packet: &[u8],
+        received: &ReceivedV6,
+        expected_sequence: u16,
+        dest: Ipv6Addr,
+        recv_time: Instant,
+    ) -> Option<ProbeResponse> {
+        let hdr = icmpv6::parse_icmpv6_header(packet)?;
+
+        if icmpv6::is_ndp(hdr.icmpv6_type) {
+            return None; // RS/RA/NS/NA/Redirect chatter
+        }
+
+        trace_time!(
+            self.verbose,
+            "Received ICMPv6 type {} code {} from {} (reply hop_limit {:?})",
+            hdr.icmpv6_type,
+            hdr.icmpv6_code,
+            icmpv6::format_ipv6_with_zone(*received.from.ip(), received.from.scope_id()),
+            received.hop_limit
+        );
+
+        match hdr.icmpv6_type {
+            icmpv6::ICMPV6_TIME_EXCEEDED | icmpv6::ICMPV6_DEST_UNREACHABLE => {
+                let embedded = icmpv6::parse_embedded_probe(packet)?;
+                // Mandatory userspace demux: embedded identifier AND
+                // sequence must match this probe; the embedded destination
+                // guards against id/seq collisions with other flows.
+                if embedded.identifier == self.icmp_identifier
+                    && embedded.sequence == expected_sequence
+                    && embedded.destination == dest
+                {
+                    let is_destination = hdr.icmpv6_type == icmpv6::ICMPV6_DEST_UNREACHABLE;
+                    return Some(ProbeResponse {
+                        from_addr: IpAddr::V6(*received.from.ip()),
+                        sequence: expected_sequence,
+                        ttl: 0, // filled by caller
+                        rtt: Duration::ZERO,
+                        received_at: recv_time,
+                        is_destination,
+                        is_timeout: false,
+                    });
+                }
+            }
+            icmpv6::ICMPV6_ECHO_REPLY => {
+                if let Some((reply_id, reply_seq)) = icmpv6::parse_echo_reply_v6(packet) {
+                    if reply_id == self.icmp_identifier && reply_seq == expected_sequence {
+                        let from_ip = *received.from.ip();
+                        return Some(ProbeResponse {
+                            from_addr: IpAddr::V6(from_ip),
+                            sequence: expected_sequence,
+                            ttl: 0, // filled by caller
+                            rtt: Duration::ZERO,
+                            received_at: recv_time,
+                            is_destination: from_ip == dest,
+                            is_timeout: false,
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        None
+    }
+
+    /// Send one hop-limited ICMPv6 echo probe and wait for its response.
+    async fn send_and_recv_probe(
+        &self,
+        dest: Ipv6Addr,
+        probe: ProbeInfo,
+    ) -> Result<ProbeResponse, TracerouteError> {
+        let send_start = probe.sent_at;
+
+        // Fresh DGRAM ICMPv6 socket per probe (per-probe hop limit without
+        // cross-probe races, mirroring the IPv4 implementation).
+        let socket =
+            Socket2::new(Domain::IPV6, Type::DGRAM, Some(Protocol::ICMPV6)).map_err(|e| {
+                TracerouteError::SocketError(format!("Failed to create ICMPv6 socket: {e}"))
+            })?;
+
+        socket.set_unicast_hops_v6(probe.ttl as u32).map_err(|e| {
+            TracerouteError::SocketError(format!("Failed to set IPV6_UNICAST_HOPS: {e}"))
+        })?;
+        socket.set_recv_hoplimit_v6(true).map_err(|e| {
+            TracerouteError::SocketError(format!("Failed to set IPV6_RECVHOPLIMIT: {e}"))
+        })?;
+        socket.set_nonblocking(true).map_err(|e| {
+            TracerouteError::SocketError(format!("Failed to set non-blocking: {e}"))
+        })?;
+        self.apply_icmp6_filter(&socket);
+
+        // Payload mirrors the IPv4 path: identifier+sequence packed at the
+        // front of a fixed-size payload (useful when eyeballing captures).
+        let payload_data = ((self.icmp_identifier as u32) << 16) | (probe.sequence as u32);
+        let mut payload = [0u8; ICMPV6_ECHO_PAYLOAD_SIZE];
+        payload[..4].copy_from_slice(&payload_data.to_be_bytes());
+
+        // Checksum stays zero: the kernel computes it on DGRAM ICMPv6 send
+        // (validated — see module docs).
+        let pkt = icmpv6::build_echo_request_v6(self.icmp_identifier, probe.sequence, &payload);
+
+        let dest_sockaddr = SockAddr::from(SocketAddrV6::new(dest, 0, 0, 0));
+        socket.send_to(&pkt, &dest_sockaddr).map_err(|e| {
+            TracerouteError::ProbeSendError(format!("Failed to send ICMPv6 packet: {e}"))
+        })?;
+
+        trace_time!(
+            self.verbose,
+            "Sent ICMPv6 echo seq={} hop_limit={} to {}",
+            probe.sequence,
+            probe.ttl,
+            dest
+        );
+
+        // Poll for a matching reply until the socket read timeout. The
+        // socket sees ALL inbound ICMPv6, so keep draining and skipping
+        // non-matching packets rather than stopping at the first one.
+        let deadline = send_start + self.timing_config.socket_read_timeout;
+        let mut buf = [0u8; RECV_BUFFER_SIZE];
+        loop {
+            if Instant::now() >= deadline {
+                break;
+            }
+            match recvmsg_v6(&socket, &mut buf) {
+                Ok(Some(received)) => {
+                    let recv_time = Instant::now();
+                    if let Some(mut response) = self.parse_response_v6(
+                        &buf[..received.bytes_len],
+                        &received,
+                        probe.sequence,
+                        dest,
+                        recv_time,
+                    ) {
+                        response.ttl = probe.ttl;
+                        response.rtt = recv_time.duration_since(send_start);
+                        trace_time!(
+                            self.verbose,
+                            "Matched ICMPv6 response for seq={} from {} rtt={:?}",
+                            probe.sequence,
+                            response.from_addr,
+                            response.rtt
+                        );
+                        if response.is_destination {
+                            self.destination_reached.store(true, Ordering::Relaxed);
+                        }
+                        self.pending_count.fetch_sub(1, Ordering::Relaxed);
+                        return Ok(response);
+                    }
+                    // Not ours — keep draining without sleeping.
+                }
+                Ok(None) => {
+                    // Nothing pending; yield until the next poll tick.
+                    tokio::time::sleep(RECV_POLL_INTERVAL).await;
+                }
+                Err(e) => {
+                    trace_time!(self.verbose, "ICMPv6 recv error: {}", e);
+                    break;
+                }
+            }
+        }
+
+        // Timeout: report it the same way the IPv4 macOS path does.
+        trace_time!(
+            self.verbose,
+            "Timeout waiting for ICMPv6 response to seq={}",
+            probe.sequence
+        );
+        self.pending_count.fetch_sub(1, Ordering::Relaxed);
+        Ok(ProbeResponse {
+            from_addr: IpAddr::V6(dest),
+            sequence: probe.sequence,
+            ttl: probe.ttl,
+            rtt: self.timing_config.socket_read_timeout,
+            received_at: Instant::now(),
+            is_destination: false,
+            is_timeout: true,
+        })
+    }
+}
+
+impl ProbeSocket for MacOSAsyncIcmpV6Socket {
+    fn mode(&self) -> ProbeMode {
+        ProbeMode::DgramIcmpv6
+    }
+
+    fn send_probe_and_recv(
+        &self,
+        dest: IpAddr,
+        probe: ProbeInfo,
+    ) -> Pin<Box<dyn Future<Output = Result<ProbeResponse, TracerouteError>> + Send + '_>> {
+        Box::pin(async move {
+            let dest_v6 = match dest {
+                IpAddr::V6(addr) => addr,
+                IpAddr::V4(_) => {
+                    return Err(TracerouteError::SocketError(
+                        "ICMPv6 socket cannot probe an IPv4 destination".to_string(),
+                    ));
+                }
+            };
+
+            self.pending_count.fetch_add(1, Ordering::Relaxed);
+            let result = self.send_and_recv_probe(dest_v6, probe).await;
+            if result.is_err() {
+                // Success and timeout paths decrement inside; keep the
+                // pending count honest on send/setup errors too.
+                self.pending_count.fetch_sub(1, Ordering::Relaxed);
+            }
+            result
+        })
+    }
+
+    fn destination_reached(&self) -> bool {
+        self.destination_reached.load(Ordering::Relaxed)
+    }
+
+    fn pending_count(&self) -> usize {
+        self.pending_count.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_next_identifier_unique_per_socket() {
+        let a = next_identifier();
+        let b = next_identifier();
+        assert_ne!(a, b, "concurrent sockets must get distinct identifiers");
+        // High byte carries the PID component for cross-process uniqueness.
+        assert_eq!(a >> 8, (std::process::id() & 0xff) as u16);
+        assert_eq!(a >> 8, b >> 8);
+    }
+
+    #[test]
+    fn test_icmp6_filter_pass_bits() {
+        // Mirror ICMP6_FILTER_SETPASS semantics for the three types the
+        // traceroute filter passes.
+        let filter = Icmp6Filter::block_all()
+            .pass(icmpv6::ICMPV6_DEST_UNREACHABLE)
+            .pass(icmpv6::ICMPV6_TIME_EXCEEDED)
+            .pass(icmpv6::ICMPV6_ECHO_REPLY);
+        let is_set = |ty: u8| filter.icmp6_filt[(ty >> 5) as usize] & (1u32 << (ty & 31)) != 0;
+        assert!(is_set(1));
+        assert!(is_set(3));
+        assert!(is_set(129));
+        // Everything else stays blocked, notably NDP and Echo Request.
+        assert!(!is_set(128));
+        for ty in 133..=137u8 {
+            assert!(!is_set(ty), "NDP type {ty} must remain blocked");
+        }
+    }
+
+    /// The parser must ignore foreign identifiers, NDP noise, and wrong
+    /// sequences — the userspace demux contract.
+    #[test]
+    fn test_parse_response_v6_filters_foreign_traffic() {
+        let sock = MacOSAsyncIcmpV6Socket {
+            icmp_identifier: 0x4242,
+            destination_reached: Arc::new(AtomicBool::new(false)),
+            pending_count: Arc::new(AtomicUsize::new(0)),
+            timing_config: TimingConfig::default(),
+            verbose: 0,
+        };
+        let dest = Ipv6Addr::new(0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888);
+        let received = ReceivedV6 {
+            bytes_len: 0,
+            from: SocketAddrV6::new(dest, 0, 0, 0),
+            hop_limit: Some(64),
+        };
+        let now = Instant::now();
+
+        // Own echo reply matches and is the destination.
+        let mut own_reply = icmpv6::build_echo_request_v6(0x4242, 7, &[]);
+        own_reply[0] = icmpv6::ICMPV6_ECHO_REPLY;
+        let resp = sock
+            .parse_response_v6(&own_reply, &received, 7, dest, now)
+            .expect("own echo reply must match");
+        assert!(resp.is_destination);
+        assert_eq!(resp.from_addr, IpAddr::V6(dest));
+
+        // Foreign identifier: skipped.
+        let mut foreign = icmpv6::build_echo_request_v6(0x9999, 7, &[]);
+        foreign[0] = icmpv6::ICMPV6_ECHO_REPLY;
+        assert!(
+            sock.parse_response_v6(&foreign, &received, 7, dest, now)
+                .is_none()
+        );
+
+        // Own identifier, wrong sequence (another probe of this trace): skipped.
+        let mut wrong_seq = icmpv6::build_echo_request_v6(0x4242, 8, &[]);
+        wrong_seq[0] = icmpv6::ICMPV6_ECHO_REPLY;
+        assert!(
+            sock.parse_response_v6(&wrong_seq, &received, 7, dest, now)
+                .is_none()
+        );
+
+        // NDP noise (Router Advertisement): skipped.
+        let ra = [134u8, 0, 0, 0, 0x40, 0xc8, 0x07, 0x08];
+        assert!(
+            sock.parse_response_v6(&ra, &received, 7, dest, now)
+                .is_none()
+        );
+    }
+
+    /// Time Exceeded demux: embedded id+seq+destination must all match.
+    #[test]
+    fn test_parse_response_v6_time_exceeded_demux() {
+        let sock = MacOSAsyncIcmpV6Socket {
+            icmp_identifier: 0x4242,
+            destination_reached: Arc::new(AtomicBool::new(false)),
+            pending_count: Arc::new(AtomicUsize::new(0)),
+            timing_config: TimingConfig::default(),
+            verbose: 0,
+        };
+        let dest = Ipv6Addr::new(0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888);
+        let hop = Ipv6Addr::new(0x2001, 0x5a8, 5, 0x403f, 0, 0, 0xf0, 2);
+        let received = ReceivedV6 {
+            bytes_len: 0,
+            from: SocketAddrV6::new(hop, 0, 0, 0),
+            hop_limit: Some(62),
+        };
+        let now = Instant::now();
+
+        // Synthesize the TE a router would send for our probe (layout
+        // matches the live capture in docs/IPV6_DESIGN.md).
+        let build_te = |id: u16, seq: u16, embedded_dst: Ipv6Addr| {
+            let mut buf = vec![0u8; 56];
+            buf[0] = icmpv6::ICMPV6_TIME_EXCEEDED;
+            buf[8] = 6 << 4; // embedded IPv6 version
+            buf[14] = icmpv6::IPV6_NEXT_HEADER_ICMPV6; // embedded next header
+            buf[32..48].copy_from_slice(&embedded_dst.octets());
+            buf[48] = icmpv6::ICMPV6_ECHO_REQUEST;
+            buf[52..54].copy_from_slice(&id.to_be_bytes());
+            buf[54..56].copy_from_slice(&seq.to_be_bytes());
+            buf
+        };
+
+        let te = build_te(0x4242, 3, dest);
+        let resp = sock
+            .parse_response_v6(&te, &received, 3, dest, now)
+            .expect("matching TE must parse");
+        assert!(!resp.is_destination);
+        assert_eq!(resp.from_addr, IpAddr::V6(hop));
+
+        // Foreign embedded identifier: someone else's expired probe.
+        let foreign_te = build_te(0x1111, 3, dest);
+        assert!(
+            sock.parse_response_v6(&foreign_te, &received, 3, dest, now)
+                .is_none()
+        );
+
+        // Matching id/seq but a different embedded destination: collision
+        // with another flow — must not be attributed to this probe.
+        let other_dst = Ipv6Addr::new(0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1111);
+        let wrong_dst_te = build_te(0x4242, 3, other_dst);
+        assert!(
+            sock.parse_response_v6(&wrong_dst_te, &received, 3, dest, now)
+                .is_none()
+        );
+    }
+}

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -9,10 +9,17 @@
 pub(crate) mod bsd;
 pub(crate) mod factory;
 pub(crate) mod icmp;
+// The ICMPv6 codec is platform-neutral and its unit tests run everywhere,
+// but only the macOS socket path consumes it so far (Linux/Windows/BSD v6
+// support is planned) — silence dead_code off-macOS until then.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) mod icmpv6;
 #[cfg(target_os = "linux")]
 pub mod linux;
 #[cfg(target_os = "macos")]
 pub(crate) mod macos;
+#[cfg(target_os = "macos")]
+pub(crate) mod macos_v6;
 pub mod traits;
 pub mod utils;
 #[cfg(target_os = "windows")]
@@ -22,7 +29,10 @@ use serde::{Deserialize, Serialize};
 
 /// IP version to use for probing
 ///
-/// Currently only IPv4 is fully supported. IPv6 support is planned for future releases.
+/// IPv4 is supported on all platforms. IPv6 probing is currently supported
+/// on macOS (unprivileged DGRAM ICMPv6); other platforms return
+/// [`TracerouteError::Ipv6NotSupported`](crate::TracerouteError::Ipv6NotSupported)
+/// for IPv6 targets until their implementations land.
 ///
 /// This enum is `#[non_exhaustive]` so downstream matches must include a
 /// wildcard arm.

--- a/src/socket/traits.rs
+++ b/src/socket/traits.rs
@@ -18,14 +18,16 @@ use std::pin::Pin;
 pub enum ProbeMode {
     /// ICMP echo requests using DGRAM sockets (Linux/macOS)
     DgramIcmp,
-    /// ICMPv6 echo requests using DGRAM sockets (macOS, unprivileged)
-    DgramIcmpv6,
     /// ICMP echo requests using Windows IcmpSendEcho2 API
     WindowsIcmp,
     /// UDP probes with IP_RECVERR (Linux)
     UdpWithRecverr,
     /// Raw ICMP sockets (fallback)
     RawIcmp,
+    /// ICMPv6 echo requests using DGRAM sockets (macOS, unprivileged)
+    // Appended last: inserting variants mid-enum shifts existing
+    // discriminants, which cargo-semver-checks flags as breaking.
+    DgramIcmpv6,
 }
 
 /// Trait for probe sockets

--- a/src/socket/traits.rs
+++ b/src/socket/traits.rs
@@ -18,6 +18,8 @@ use std::pin::Pin;
 pub enum ProbeMode {
     /// ICMP echo requests using DGRAM sockets (Linux/macOS)
     DgramIcmp,
+    /// ICMPv6 echo requests using DGRAM sockets (macOS, unprivileged)
+    DgramIcmpv6,
     /// ICMP echo requests using Windows IcmpSendEcho2 API
     WindowsIcmp,
     /// UDP probes with IP_RECVERR (Linux)

--- a/src/traceroute.rs
+++ b/src/traceroute.rs
@@ -37,8 +37,9 @@ use serde::{Deserialize, Serialize};
 use std::net::Ipv4Addr;
 
 // Re-export commonly used types
+pub use api::resolve_target_with_family;
 pub use api::{Traceroute, trace_async as trace, trace_with_config_async as trace_with_config};
-pub use config::{TimingConfig, TracerouteConfig, TracerouteConfigBuilder};
+pub use config::{PreferredFamily, TimingConfig, TracerouteConfig, TracerouteConfigBuilder};
 pub use error::{ConfigError, TracerouteError};
 pub use result::{TracerouteProgress, TracerouteResult};
 pub use types::{ClassifiedHopInfo, IspInfo, RawHopInfo};
@@ -95,6 +96,24 @@ pub fn is_internal_ip(ip: &Ipv4Addr) -> bool {
 pub fn is_cgnat(ip: &Ipv4Addr) -> bool {
     let octets = ip.octets();
     octets[0] == 100 && (64..=127).contains(&octets[1])
+}
+
+/// Checks if an IPv6 address is within private/internal ranges — the
+/// LAN-equivalent scopes for segment classification:
+///
+/// - loopback `::1` (RFC 4291 section 2.5.3)
+/// - link-local unicast `fe80::/10` (RFC 4291 section 2.5.6)
+/// - unique local addresses `fc00::/7` (RFC 4193 section 3.1)
+///
+/// Bit checks are written out explicitly (rather than via the
+/// `Ipv6Addr::is_*` helpers) so each range is auditable against its RFC.
+pub fn is_internal_ipv6(ip: &std::net::Ipv6Addr) -> bool {
+    let first_segment = ip.segments()[0];
+    ip.is_loopback()
+        // fe80::/10: top 10 bits are 1111 1110 10
+        || (first_segment & 0xffc0) == 0xfe80
+        // fc00::/7: top 7 bits are 1111 110
+        || (first_segment & 0xfe00) == 0xfc00
 }
 
 /// Parse an ASN string into components
@@ -223,6 +242,39 @@ mod tests {
         // Other IPs
         assert!(!is_cgnat(&"8.8.8.8".parse().unwrap()));
         assert!(!is_cgnat(&"192.168.1.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_is_internal_ipv6() {
+        use std::net::Ipv6Addr;
+        // Loopback
+        assert!(is_internal_ipv6(&Ipv6Addr::LOCALHOST));
+        // Link-local fe80::/10 spans fe80:: through febf:ffff:...
+        assert!(is_internal_ipv6(&"fe80::1".parse::<Ipv6Addr>().unwrap()));
+        assert!(is_internal_ipv6(
+            &"febf:ffff::1".parse::<Ipv6Addr>().unwrap()
+        ));
+        // Just outside link-local
+        assert!(!is_internal_ipv6(&"fec0::1".parse::<Ipv6Addr>().unwrap()));
+        assert!(!is_internal_ipv6(&"fe7f::1".parse::<Ipv6Addr>().unwrap()));
+        // ULA fc00::/7 spans fc00:: through fdff:ffff:...
+        assert!(is_internal_ipv6(&"fc00::1".parse::<Ipv6Addr>().unwrap()));
+        assert!(is_internal_ipv6(
+            &"fd12:3456:789a::1".parse::<Ipv6Addr>().unwrap()
+        ));
+        assert!(is_internal_ipv6(
+            &"fdff:ffff::ffff".parse::<Ipv6Addr>().unwrap()
+        ));
+        // Just outside ULA
+        assert!(!is_internal_ipv6(&"fbff::1".parse::<Ipv6Addr>().unwrap()));
+        // Global unicast and unspecified are not internal
+        assert!(!is_internal_ipv6(
+            &"2001:4860:4860::8888".parse::<Ipv6Addr>().unwrap()
+        ));
+        assert!(!is_internal_ipv6(
+            &"2606:4700::1".parse::<Ipv6Addr>().unwrap()
+        ));
+        assert!(!is_internal_ipv6(&Ipv6Addr::UNSPECIFIED));
     }
 
     #[test]

--- a/src/traceroute/api.rs
+++ b/src/traceroute/api.rs
@@ -6,6 +6,7 @@
 use crate::dns::resolver;
 use crate::services::Services;
 use crate::socket::factory::create_probe_socket_with_options_and_verbose;
+use crate::traceroute::config::PreferredFamily;
 use crate::traceroute::engine::TracerouteEngine;
 use crate::traceroute::{TracerouteConfig, TracerouteError, TracerouteResult};
 use std::net::IpAddr;
@@ -33,39 +34,24 @@ impl Traceroute {
         })
     }
 
-    /// Resolve the target hostname/IP to an IpAddr
+    /// Resolve the target hostname/IP to an IpAddr, honoring the
+    /// configuration's family preference
     async fn resolve_target(config: &mut TracerouteConfig) -> Result<IpAddr, TracerouteError> {
-        // Check if target is an IP address literal
-        if let Ok(ip) = config.target.parse::<IpAddr>() {
-            if ip.is_ipv6() {
-                return Err(TracerouteError::Ipv6NotSupported);
+        // IP literals and "localhost" resolve deterministically and take
+        // precedence over a pre-set target_ip (pre-0.9 precedence order).
+        let target_is_literal =
+            config.target.parse::<IpAddr>().is_ok() || config.target == "localhost";
+
+        if !target_is_literal {
+            // Already resolved (skips DNS): validate the family preference
+            // still holds, then use it.
+            if let Some(ip) = config.target_ip {
+                check_family(ip, config.preferred_family, &config.target)?;
+                return Ok(ip);
             }
-            config.target_ip = Some(ip);
-            return Ok(ip);
         }
 
-        // Handle well-known hostnames
-        if config.target == "localhost" {
-            let ip = IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
-            config.target_ip = Some(ip);
-            return Ok(ip);
-        }
-
-        // Already resolved
-        if let Some(ip) = config.target_ip {
-            return Ok(ip);
-        }
-
-        // Resolve hostname to IPv4 via DNS
-        let addrs = resolver::resolve_a(&config.target)
-            .await
-            .map_err(|e| TracerouteError::ResolutionError(e.to_string()))?;
-
-        let ip =
-            IpAddr::V4(*addrs.first().ok_or_else(|| {
-                TracerouteError::ResolutionError("No addresses found".to_string())
-            })?);
-
+        let ip = resolve_target_with_family(&config.target, config.preferred_family).await?;
         config.target_ip = Some(ip);
         Ok(ip)
     }
@@ -121,6 +107,113 @@ impl Traceroute {
     }
 }
 
+/// Validate that a resolved/literal address matches an explicit family
+/// preference. `Auto` accepts either family; the family always lives in the
+/// error *message* (context), never in a distinct error type.
+fn check_family(ip: IpAddr, family: PreferredFamily, target: &str) -> Result<(), TracerouteError> {
+    match (family, ip) {
+        (PreferredFamily::V4, IpAddr::V6(_)) => Err(TracerouteError::ResolutionError(format!(
+            "{target} is an IPv6 address but IPv4 was requested (-4)"
+        ))),
+        (PreferredFamily::V6, IpAddr::V4(_)) => Err(TracerouteError::ResolutionError(format!(
+            "{target} is an IPv4 address but IPv6 was requested (-6)"
+        ))),
+        _ => Ok(()),
+    }
+}
+
+/// Resolve a traceroute target (IP literal or hostname) to a single address
+/// of the preferred family.
+///
+/// - **IP literals** are used directly; an explicit `V4`/`V6` preference
+///   that contradicts the literal's family is a
+///   [`TracerouteError::ResolutionError`].
+/// - **`localhost`** short-circuits to `127.0.0.1` (or `::1` under
+///   [`PreferredFamily::V6`]) without touching DNS.
+/// - **Hostnames** resolve per the preference. `V4` uses ftr's own DNS
+///   resolver (A query) exactly as previous releases did. `V6` uses the
+///   system resolver (`getaddrinfo` via tokio's `lookup_host`) and keeps
+///   only IPv6 addresses; the system resolver is used deliberately so OS
+///   facilities like macOS NAT64/DNS64 synthesis apply. `Auto` prefers
+///   IPv4 and only falls back to IPv6 when no A records exist (see
+///   [`PreferredFamily`] for why this conservative default was chosen).
+///
+/// Zone-scoped literals (`fe80::1%en0`) are rejected with a clear error
+/// rather than silently stripping the zone: `IpAddr` cannot carry a scope
+/// id, and tracerouting a link-local neighbor is a single-hop affair.
+/// First-class scoped-target support needs an API extension (deferred).
+pub async fn resolve_target_with_family(
+    target: &str,
+    family: PreferredFamily,
+) -> Result<IpAddr, TracerouteError> {
+    // Zone-scoped IPv6 literal: refuse loudly, never strip the zone.
+    if let Some((addr_part, zone)) = target.split_once('%') {
+        if addr_part.parse::<std::net::Ipv6Addr>().is_ok() {
+            return Err(TracerouteError::ResolutionError(format!(
+                "zone-scoped IPv6 targets ({addr_part}%{zone}) are not yet supported"
+            )));
+        }
+    }
+
+    // IP literal: use as-is (after family validation).
+    if let Ok(ip) = target.parse::<IpAddr>() {
+        check_family(ip, family, target)?;
+        return Ok(ip);
+    }
+
+    // Well-known hostname, no DNS needed.
+    if target == "localhost" {
+        return Ok(match family {
+            PreferredFamily::V6 => IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+            _ => IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+        });
+    }
+
+    match family {
+        PreferredFamily::V4 => resolve_first_a(target).await,
+        PreferredFamily::V6 => resolve_first_aaaa(target).await,
+        _ => {
+            // Auto: IPv4 first — identical mechanism and result to pre-0.9
+            // releases for any host with A records — then IPv6.
+            match resolve_first_a(target).await {
+                Ok(ip) => Ok(ip),
+                Err(v4_err) => match resolve_first_aaaa(target).await {
+                    Ok(ip) => Ok(ip),
+                    Err(_) => Err(v4_err),
+                },
+            }
+        }
+    }
+}
+
+/// Resolve a hostname's first A record via ftr's own DNS resolver — the
+/// exact IPv4 mechanism used by previous releases.
+async fn resolve_first_a(target: &str) -> Result<IpAddr, TracerouteError> {
+    let addrs = resolver::resolve_a(target)
+        .await
+        .map_err(|e| TracerouteError::ResolutionError(format!("{target}: {e}")))?;
+    addrs
+        .first()
+        .map(|a| IpAddr::V4(*a))
+        .ok_or_else(|| TracerouteError::ResolutionError(format!("{target}: no IPv4 addresses")))
+}
+
+/// Resolve a hostname's first IPv6 address via the system resolver
+/// (`getaddrinfo`), so OS-level behaviors (NAT64/DNS64 synthesis,
+/// /etc/hosts entries) apply to IPv6 targets.
+async fn resolve_first_aaaa(target: &str) -> Result<IpAddr, TracerouteError> {
+    let addrs = tokio::net::lookup_host((target, 0))
+        .await
+        .map_err(|e| TracerouteError::ResolutionError(format!("{target}: {e}")))?;
+    addrs
+        .into_iter()
+        .find(std::net::SocketAddr::is_ipv6)
+        .map(|a| a.ip())
+        .ok_or_else(|| {
+            TracerouteError::ResolutionError(format!("{target}: no IPv6 (AAAA) addresses"))
+        })
+}
+
 /// Run an async traceroute with the given configuration
 pub async fn trace_async(target: &str) -> Result<TracerouteResult, TracerouteError> {
     // ConfigError converts into TracerouteError::ConfigError via #[from]
@@ -168,18 +261,89 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_async_traceroute_ipv6_error() {
+    async fn test_async_traceroute_ipv6_literal_resolves() {
+        // IPv6 literals now resolve at creation time; platforms without
+        // IPv6 probe support surface Ipv6NotSupported later, from the
+        // socket factory, when the trace runs.
         let config = TracerouteConfig::builder()
             .target("::1")
             .target_ip(IpAddr::V6("::1".parse().expect("valid IPv6 address")))
             .build()
             .expect("failed to build traceroute config");
 
-        let result = Traceroute::new(config).await;
+        let traceroute = Traceroute::new(config)
+            .await
+            .expect("IPv6 literal must resolve");
+        assert_eq!(
+            traceroute.target_ip,
+            IpAddr::V6("::1".parse().expect("valid IPv6 address"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_ip_literals_by_family() {
+        use crate::traceroute::config::PreferredFamily;
+
+        // Literals pass through untouched under Auto and their own family.
+        for family in [PreferredFamily::Auto, PreferredFamily::V4] {
+            let ip = resolve_target_with_family("8.8.8.8", family)
+                .await
+                .expect("v4 literal resolves");
+            assert_eq!(ip, IpAddr::V4("8.8.8.8".parse().expect("valid IPv4")));
+        }
+        for family in [PreferredFamily::Auto, PreferredFamily::V6] {
+            let ip = resolve_target_with_family("2001:4860:4860::8888", family)
+                .await
+                .expect("v6 literal resolves");
+            assert_eq!(
+                ip,
+                IpAddr::V6("2001:4860:4860::8888".parse().expect("valid IPv6"))
+            );
+        }
+
+        // Family/literal contradictions are resolution errors whose message
+        // carries the family context (no dedicated error type).
+        let err = resolve_target_with_family("8.8.8.8", PreferredFamily::V6)
+            .await
+            .expect_err("v4 literal under -6 must fail");
+        assert!(matches!(&err, TracerouteError::ResolutionError(m) if m.contains("IPv6")));
+
+        let err = resolve_target_with_family("2001:4860:4860::8888", PreferredFamily::V4)
+            .await
+            .expect_err("v6 literal under -4 must fail");
+        assert!(matches!(&err, TracerouteError::ResolutionError(m) if m.contains("IPv4")));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_localhost_by_family() {
+        use crate::traceroute::config::PreferredFamily;
+
+        assert_eq!(
+            resolve_target_with_family("localhost", PreferredFamily::Auto)
+                .await
+                .expect("localhost resolves"),
+            IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+        );
+        assert_eq!(
+            resolve_target_with_family("localhost", PreferredFamily::V6)
+                .await
+                .expect("localhost -6 resolves"),
+            IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_rejects_zone_scoped_literal() {
+        use crate::traceroute::config::PreferredFamily;
+
+        // The zone must never be silently stripped; scoped targets are a
+        // clear, typed error until the API can carry a scope id end-to-end.
+        let err = resolve_target_with_family("fe80::1%en0", PreferredFamily::Auto)
+            .await
+            .expect_err("zone-scoped literal must be rejected");
         assert!(
-            matches!(&result, Err(TracerouteError::Ipv6NotSupported)),
-            "Expected IPv6 not supported error, got: {:?}",
-            result
+            matches!(&err, TracerouteError::ResolutionError(m) if m.contains("zone-scoped")),
+            "unexpected error: {err:?}"
         );
     }
 

--- a/src/traceroute/config.rs
+++ b/src/traceroute/config.rs
@@ -52,6 +52,31 @@ impl Default for TimingConfig {
     }
 }
 
+/// Address family preference for hostname resolution
+///
+/// Controls which IP family a hostname target resolves to. IP-literal
+/// targets are used as-is (an explicit `V4`/`V6` preference that
+/// contradicts the literal's family is a resolution error).
+///
+/// # Default (`Auto`)
+///
+/// `Auto` prefers IPv4 when a host has both A and AAAA records, and uses
+/// IPv6 only when the host is v6-only. This is a deliberately conservative
+/// default while IPv6 probing is new (currently macOS-only): a dual-stack
+/// host keeps yielding exactly the same trace as previous ftr releases on
+/// every platform, and platforms without IPv6 probe support quietly keep
+/// working. Pass `V6` (CLI `-6`) to opt in for dual-stack hosts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum PreferredFamily {
+    /// Only resolve to IPv4; error if the host has no A records
+    V4,
+    /// Only resolve to IPv6; error if the host has no AAAA records
+    V6,
+    /// Prefer IPv4 when available, fall back to IPv6 (see type-level docs)
+    #[default]
+    Auto,
+}
+
 /// Configuration for a traceroute operation
 ///
 /// This struct contains all the parameters needed to control a traceroute operation.
@@ -105,6 +130,12 @@ pub struct TracerouteConfig {
     /// When running multiple traceroutes, you can provide the public IP
     /// to avoid repeated detection calls, improving performance.
     pub public_ip: Option<IpAddr>,
+    /// Address family preference for hostname resolution (default: Auto)
+    ///
+    /// `#[serde(default)]` keeps configurations serialized by pre-0.9
+    /// versions deserializable.
+    #[serde(default)]
+    pub preferred_family: PreferredFamily,
     /// Internal timing configuration
     /// Most users should not need to modify these values
     pub timing: TimingConfig,
@@ -128,6 +159,7 @@ impl Default for TracerouteConfig {
             enable_rdns: true,
             verbose: 0,
             public_ip: None,
+            preferred_family: PreferredFamily::default(),
             timing: TimingConfig::default(),
         }
     }
@@ -360,6 +392,16 @@ impl TracerouteConfigBuilder {
     /// multiple traceroutes to improve performance.
     pub fn public_ip(mut self, ip: IpAddr) -> Self {
         self.config.public_ip = Some(ip);
+        self
+    }
+
+    /// Set the address family preference for hostname resolution
+    ///
+    /// See [`PreferredFamily`] for the semantics of each option; the
+    /// default is [`PreferredFamily::Auto`] (IPv4 preferred when a host
+    /// has both families).
+    pub fn preferred_family(mut self, family: PreferredFamily) -> Self {
+        self.config.preferred_family = family;
         self
     }
 

--- a/src/traceroute/engine.rs
+++ b/src/traceroute/engine.rs
@@ -457,54 +457,43 @@ impl TracerouteEngine {
                         let hostname = enrichment.and_then(|e| e.hostname.clone());
                         let asn_info = enrichment.and_then(|e| e.asn_info.clone());
 
-                        // Classify segment
-                        let segment = if let IpAddr::V4(ipv4) = addr {
-                            if crate::traceroute::is_internal_ip(&ipv4) {
-                                SegmentType::Lan
-                            } else if crate::traceroute::is_cgnat(&ipv4) {
-                                in_isp_segment = true;
-                                SegmentType::Isp
-                            } else {
-                                // Public IP classification requires ISP and/or destination ASN
-                                if let Some(ref asn) = asn_info {
-                                    // ISP boundary check if known
-                                    if let Some(isp) = isp_asn {
-                                        if asn.asn == isp {
-                                            in_isp_segment = true;
-                                            SegmentType::Isp
-                                        } else if let Some(ref dest) = dest_asn {
-                                            if asn.asn == dest.asn {
-                                                SegmentType::Destination
-                                            } else {
-                                                SegmentType::Transit
-                                            }
-                                        } else {
-                                            // ISP known but not this AS; without dest ASN, mark as TRANSIT
-                                            SegmentType::Transit
-                                        }
-                                    } else if let Some(ref dest) = dest_asn {
-                                        if asn.asn == dest.asn {
-                                            SegmentType::Destination
-                                        } else if in_isp_segment {
-                                            SegmentType::Transit
-                                        } else {
-                                            SegmentType::Unknown
-                                        }
-                                    } else if in_isp_segment {
-                                        SegmentType::Transit
-                                    } else {
-                                        SegmentType::Unknown
-                                    }
-                                } else if in_isp_segment {
-                                    // Public IP after ISP without ASN = likely IXP/peering point
-                                    SegmentType::Transit
+                        // Classify segment. Private/internal ranges are LAN
+                        // for both families; CGNAT is v4-only; public
+                        // addresses share the ASN-based classification.
+                        let segment = match addr {
+                            IpAddr::V4(ipv4) => {
+                                if crate::traceroute::is_internal_ip(&ipv4) {
+                                    SegmentType::Lan
+                                } else if crate::traceroute::is_cgnat(&ipv4) {
+                                    in_isp_segment = true;
+                                    SegmentType::Isp
                                 } else {
-                                    // Public IP without ASN before ISP boundary = assume transit
-                                    SegmentType::Transit
+                                    Self::classify_public_hop(
+                                        asn_info.as_ref(),
+                                        isp_asn,
+                                        dest_asn.as_ref(),
+                                        &mut in_isp_segment,
+                                    )
                                 }
                             }
-                        } else {
-                            SegmentType::Unknown
+                            IpAddr::V6(ipv6) => {
+                                if crate::traceroute::is_internal_ipv6(&ipv6) {
+                                    // Link-local (fe80::/10) and ULA
+                                    // (fc00::/7) hops are LAN-equivalent.
+                                    SegmentType::Lan
+                                } else {
+                                    // Global unicast: same ASN logic as v4.
+                                    // Absent ASN data (e.g. v6 enrichment
+                                    // unavailable) this degrades gracefully
+                                    // to TRANSIT/UNKNOWN, never panics.
+                                    Self::classify_public_hop(
+                                        asn_info.as_ref(),
+                                        isp_asn,
+                                        dest_asn.as_ref(),
+                                        &mut in_isp_segment,
+                                    )
+                                }
+                            }
                         };
 
                         hop_infos.push(ClassifiedHopInfo {
@@ -551,7 +540,10 @@ impl TracerouteEngine {
 
         // Determine protocol and socket mode
         let (protocol_used, socket_mode_used) = match self.socket.mode() {
-            crate::socket::traits::ProbeMode::DgramIcmp => (ProbeProtocol::Icmp, SocketMode::Dgram),
+            crate::socket::traits::ProbeMode::DgramIcmp
+            | crate::socket::traits::ProbeMode::DgramIcmpv6 => {
+                (ProbeProtocol::Icmp, SocketMode::Dgram)
+            }
             crate::socket::traits::ProbeMode::WindowsIcmp => (ProbeProtocol::Icmp, SocketMode::Raw),
             crate::socket::traits::ProbeMode::UdpWithRecverr => {
                 (ProbeProtocol::Udp, SocketMode::Dgram)
@@ -576,6 +568,57 @@ impl TracerouteEngine {
             destination_reached,
             total_duration: elapsed,
         })
+    }
+
+    /// Classify a public (non-private, non-CGNAT) hop of either address
+    /// family from its ASN relative to the ISP and destination ASNs.
+    ///
+    /// `in_isp_segment` is set when the hop is inside the ISP's AS so later
+    /// unclassifiable hops lean TRANSIT rather than UNKNOWN. All inputs are
+    /// optional: with no ASN data at all this returns TRANSIT/UNKNOWN,
+    /// which the sandwich pass may later refine.
+    fn classify_public_hop(
+        asn_info: Option<&AsnInfo>,
+        isp_asn: Option<u32>,
+        dest_asn: Option<&AsnInfo>,
+        in_isp_segment: &mut bool,
+    ) -> SegmentType {
+        if let Some(asn) = asn_info {
+            // ISP boundary check if known
+            if let Some(isp) = isp_asn {
+                if asn.asn == isp {
+                    *in_isp_segment = true;
+                    SegmentType::Isp
+                } else if let Some(dest) = dest_asn {
+                    if asn.asn == dest.asn {
+                        SegmentType::Destination
+                    } else {
+                        SegmentType::Transit
+                    }
+                } else {
+                    // ISP known but not this AS; without dest ASN, mark as TRANSIT
+                    SegmentType::Transit
+                }
+            } else if let Some(dest) = dest_asn {
+                if asn.asn == dest.asn {
+                    SegmentType::Destination
+                } else if *in_isp_segment {
+                    SegmentType::Transit
+                } else {
+                    SegmentType::Unknown
+                }
+            } else if *in_isp_segment {
+                SegmentType::Transit
+            } else {
+                SegmentType::Unknown
+            }
+        } else if *in_isp_segment {
+            // Public IP after ISP without ASN = likely IXP/peering point
+            SegmentType::Transit
+        } else {
+            // Public IP without ASN before ISP boundary = assume transit
+            SegmentType::Transit
+        }
     }
 
     /// Apply sandwich logic: if Unknown/Transit hops are between two hops of the same segment type,

--- a/tests/error_handling_test.rs
+++ b/tests/error_handling_test.rs
@@ -73,7 +73,7 @@ async fn test_tcp_not_implemented_error() {
 }
 
 #[tokio::test]
-async fn test_ipv6_not_supported_error() {
+async fn test_ipv6_target_platform_behavior() {
     let config = TracerouteConfigBuilder::new()
         .target("::1") // IPv6 localhost
         .build()
@@ -82,12 +82,28 @@ async fn test_ipv6_not_supported_error() {
     let ftr_instance = ftr::Ftr::new();
     let result = ftr_instance.trace_with_config(config).await;
 
-    assert!(
-        matches!(&result, Err(TracerouteError::Ipv6NotSupported)),
-        "Expected Ipv6NotSupported error, got: {:?}",
-        result
-    );
-    println!("Got expected Ipv6NotSupported error");
+    // macOS has unprivileged DGRAM ICMPv6 traceroute; a loopback trace
+    // reaches ::1 in one hop, classified as LAN. Platforms without IPv6
+    // probe support must surface the typed Ipv6NotSupported error.
+    #[cfg(target_os = "macos")]
+    {
+        let trace = result.expect("IPv6 loopback trace should succeed unprivileged on macOS");
+        assert!(trace.destination_reached, "::1 must be reachable");
+        assert_eq!(
+            trace.hops.first().and_then(|h| h.addr),
+            Some("::1".parse().expect("valid IPv6")),
+        );
+        println!("IPv6 loopback trace succeeded on macOS");
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        assert!(
+            matches!(&result, Err(TracerouteError::Ipv6NotSupported)),
+            "Expected Ipv6NotSupported error, got: {:?}",
+            result
+        );
+        println!("Got expected Ipv6NotSupported error");
+    }
 }
 
 #[tokio::test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -282,8 +282,15 @@ async fn test_error_types() {
         result
     );
 
-    // Test IPv6 not supported
+    // IPv6 targets: unprivileged DGRAM ICMPv6 traceroute on macOS; the
+    // typed Ipv6NotSupported error on platforms without v6 probe support.
     let result = trace("::1").await;
+    #[cfg(target_os = "macos")]
+    {
+        let v6_trace = result.expect("IPv6 loopback trace should succeed on macOS");
+        assert!(v6_trace.destination_reached);
+    }
+    #[cfg(not(target_os = "macos"))]
     assert!(
         matches!(&result, Err(TracerouteError::Ipv6NotSupported)),
         "Expected Ipv6NotSupported error, got: {:?}",

--- a/tests/ipv6_integration.rs
+++ b/tests/ipv6_integration.rs
@@ -1,0 +1,159 @@
+//! Live IPv6 traceroute integration tests
+//!
+//! These tests send real ICMPv6 probes over the network, so they are
+//! opt-in: set `FTR_TEST_IPV6=1` to run them (GitHub-hosted runners have
+//! no IPv6 connectivity, and even local machines may be v4-only). They
+//! run unprivileged by design — the macOS DGRAM ICMPv6 path needs no root
+//! (validated in docs/IPV6_DESIGN.md).
+//!
+//! ```bash
+//! FTR_TEST_IPV6=1 cargo test --test ipv6_integration -- --nocapture
+//! ```
+
+use ftr::{Ftr, PreferredFamily, TracerouteConfig, TracerouteError};
+use std::net::IpAddr;
+
+/// Google Public DNS IPv6 anycast — the same reliable target the
+/// validation spikes used.
+const V6_TARGET: &str = "2001:4860:4860::8888";
+
+/// Returns true (and prints why) when live IPv6 tests should be skipped.
+fn skip_live_ipv6() -> bool {
+    if std::env::var("FTR_TEST_IPV6").as_deref() != Ok("1") {
+        eprintln!("Skipping live IPv6 test (set FTR_TEST_IPV6=1 to enable)");
+        return true;
+    }
+    false
+}
+
+/// Assert an address renders in RFC 5952 canonical form: parsing its own
+/// Display output must round-trip, and the string must be lowercase.
+fn assert_canonical(addr: IpAddr) {
+    let s = addr.to_string();
+    assert_eq!(
+        s.parse::<IpAddr>().expect("address string must re-parse"),
+        addr,
+        "address must round-trip through its Display form"
+    );
+    assert_eq!(
+        s,
+        s.to_lowercase(),
+        "RFC 5952 requires lowercase hex digits"
+    );
+    assert!(!s.contains("%"), "IpAddr display never carries a zone");
+}
+
+#[tokio::test]
+async fn test_live_ipv6_trace_to_google_dns() {
+    if skip_live_ipv6() {
+        return;
+    }
+
+    let config = TracerouteConfig::builder()
+        .target(V6_TARGET)
+        .max_hops(30)
+        // Enrichment intentionally left enabled: classification must
+        // degrade gracefully, not crash, even before v6 ASN enrichment
+        // lands (it ships in a concurrent PR).
+        .build()
+        .expect("config builds");
+
+    let ftr = Ftr::new();
+    let result = ftr.trace_with_config(config).await;
+    if matches!(result, Err(TracerouteError::Ipv6NotSupported)) {
+        // Non-macOS platforms: typed error is the correct outcome.
+        eprintln!("IPv6 probing not supported on this platform — typed error OK");
+        return;
+    }
+    let result = result.expect("live IPv6 trace should succeed");
+
+    assert_eq!(
+        result.target_ip,
+        V6_TARGET.parse::<IpAddr>().expect("valid literal")
+    );
+    assert!(
+        result.destination_reached,
+        "destination {V6_TARGET} should be reached"
+    );
+
+    // At least one intermediate hop (an address that is not the target)
+    // must have answered — proof the Time Exceeded path works.
+    let intermediate_hops: Vec<_> = result
+        .hops
+        .iter()
+        .filter(|h| h.addr.is_some() && h.addr != Some(result.target_ip))
+        .collect();
+    assert!(
+        !intermediate_hops.is_empty(),
+        "expected at least one intermediate hop, got only: {:?}",
+        result.hops
+    );
+
+    // Every responding hop must be IPv6 and render canonically.
+    for hop in result.hops.iter().filter_map(|h| h.addr) {
+        assert!(hop.is_ipv6(), "IPv6 trace must not report IPv4 hops: {hop}");
+        assert_canonical(hop);
+    }
+
+    eprintln!(
+        "live IPv6 trace: {} hops, {} intermediate, destination reached in {:?}",
+        result.hop_count(),
+        intermediate_hops.len(),
+        result.total_duration
+    );
+    for hop in &result.hops {
+        eprintln!(
+            "  {:2} [{}] {:?} {:?}",
+            hop.ttl, hop.segment, hop.addr, hop.rtt
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_live_ipv6_hostname_resolution_forced_v6() {
+    if skip_live_ipv6() {
+        return;
+    }
+
+    // google.com is dual-stack; -6 must yield an IPv6 address.
+    let ip = ftr::resolve_target_with_family("google.com", PreferredFamily::V6)
+        .await
+        .expect("google.com must resolve under -6");
+    assert!(ip.is_ipv6(), "forced V6 resolution returned {ip}");
+    assert_canonical(ip);
+
+    // Auto on a dual-stack host prefers IPv4 (documented conservative
+    // default while v6 probing is new).
+    let ip = ftr::resolve_target_with_family("google.com", PreferredFamily::Auto)
+        .await
+        .expect("google.com must resolve under Auto");
+    assert!(ip.is_ipv4(), "Auto must prefer IPv4 for dual-stack hosts");
+}
+
+#[tokio::test]
+async fn test_live_ipv6_trace_via_hostname() {
+    if skip_live_ipv6() {
+        return;
+    }
+
+    let config = TracerouteConfig::builder()
+        .target("google.com")
+        .preferred_family(PreferredFamily::V6)
+        .max_hops(30)
+        .build()
+        .expect("config builds");
+
+    let ftr = Ftr::new();
+    let result = ftr.trace_with_config(config).await;
+    if matches!(result, Err(TracerouteError::Ipv6NotSupported)) {
+        eprintln!("IPv6 probing not supported on this platform — typed error OK");
+        return;
+    }
+    let result = result.expect("live IPv6 hostname trace should succeed");
+
+    assert!(result.target_ip.is_ipv6(), "-6 trace must probe IPv6");
+    assert!(
+        result.destination_reached,
+        "google.com over IPv6 should be reachable"
+    );
+}


### PR DESCRIPTION
Implements core IPv6 traceroute support per `docs/IPV6_DESIGN.md` (issue #22), porting the mechanics proven live by `examples/spike_icmpv6_socket.rs` and `examples/spike_traceroute6.rs`.

## What's included

### 1. ICMPv6 codec (`src/socket/icmpv6.rs`)
- Echo Request builder with **checksum left zero** — the kernel computes it on DGRAM ICMPv6 sockets (spike-validated; the checksum covers the IPv6 pseudo-header which userspace can't know pre-send).
- Receive buffers are parsed **starting at the ICMPv6 header** — the kernel never prepends the IPv6 header (RFC 3542 behavior, validated).
- Time Exceeded / Destination Unreachable parser walks the RFC 4443 §3.3 layout (8B error header + fixed 40B invoking IPv6 header + 8B invoking echo header), validating embedded IP version, Next Header == 58, and embedded type == Echo Request, and returns the **embedded identifier, sequence, and destination** for the caller to check.
- NDP noise (types 133–137) recognized and skipped.
- Dense unit tests on synthetic buffers, including RFC 5952 canonicality tests (`::`, `::1`, longest-run compression, lowercase, `::ffff:1.2.3.4`) and `%zone` formatting tests.

### 2. macOS unprivileged ICMPv6 socket (`src/socket/macos_v6.rs`)
- `Domain::IPV6`/`Type::DGRAM`/`Protocol::ICMPV6` per-probe sockets — **no root required**.
- `IPV6_UNICAST_HOPS` for hop limiting; `IPV6_RECVHOPLIMIT` + `recvmsg` cmsg parsing for the reply hop limit (surfaced in `-vv` diagnostics).
- `ICMP6_FILTER` via raw setsockopt (optname 18, cited against macOS SDK `netinet6/in6.h` line 392; BSD bit=PASS semantics) passing types 1/3/129 only — applied strictly as a best-effort kernel noise filter.
- **Mandatory userspace filtering**: Darwin does NOT demux ICMPv6 DGRAM by echo id (spike-proven — every socket sees every process's replies plus NDP chatter), so every receive validates identifier + sequence on Echo Replies AND the embedded id/seq/destination inside error messages. Non-matching packets are skipped silently.
- Unique identifier per concurrent socket (PID low byte + per-process counter — SwiftFTR lesson).
- New `ProbeMode::DgramIcmpv6` variant (additive on a `#[non_exhaustive]` enum); wired into `factory.rs` for `IpAddr::V6` on macOS. Other platforms keep returning the typed `Ipv6NotSupported`.

**Fit with the Linux findings (PR #38):** identifier selection/validation is fully encapsulated inside the platform socket impl — the `ProbeSocket` trait, engine, and codec API carry no "caller chooses the id" invariant (codec parsers *return* parsed ids for the caller to check). The Linux model (kernel-assigned id read back per-socket, sequence-only matching, `IPV6_RECVERR`/errqueue receive, inverted ICMP6_FILTER semantics) drops in as its own `ProbeSocket` impl with **zero trait changes**.

### 3. Family-agnostic resolution + CLI
- New `PreferredFamily { V4, V6, Auto }` config + `preferred_family()` builder + `-4`/`-6` CLI flags (`conflicts_with` each other).
- **Auto prefers IPv4 for dual-stack hosts** and uses IPv6 only for v6-only hosts — a documented, conservative default while v6 probing is new (macOS-only): existing users' traces are byte-identical, and platforms without v6 support quietly keep working. Explicit `-6` opts in; on unsupported platforms it yields the typed `Ipv6NotSupported`.
- `V4` keeps the exact pre-0.9 resolution mechanism (ftr's own A-record resolver). `V6` uses the system resolver (`getaddrinfo` via tokio `lookup_host`) so macOS NAT64/DNS64 synthesis applies.
- Zone-scoped literals (`fe80::1%en0`) are **rejected with a clear error** — never silently stripped. First-class scoped-target plumbing needs an API extension (deferred; `IpAddr` can't carry a scope id). The receive path preserves `sin6_scope_id` from the sender sockaddr and a `format_ipv6_with_zone` helper (with `if_indextoname` naming) covers display where representable.

### 4. Segment classification for v6
- `fe80::/10`, `fc00::/7`, and `::1` → LAN (RFC-cited bit checks in `is_internal_ipv6`).
- Global unicast shares the v4 ASN-based ISP/TRANSIT/DESTINATION logic (extracted into `classify_public_hop`), degrading gracefully to TRANSIT/UNKNOWN while v6 ASN enrichment lands in the concurrent enrichment PR — no crashes or misclassification on absent ASN data.

### 5. Output
- v6 addresses render RFC 5952-canonically in both text and JSON paths (Rust's `Ipv6Addr` Display, verified by tests). JSON shape unchanged (snake_case, additive only).

## Live validation (this machine: macOS, dual-stack Sonic fiber, **unprivileged**)

`cargo run -- -6 google.com` (no sudo):

```
ftr to google.com (2607:f8b0:4005:806::200e), 30 max hops, 1000ms probe timeout, 3000ms overall timeout

Performing ASN lookups, reverse DNS lookups and classifying segments...
 1 [TRANSIT] unifi.localdomain (2001:5a8:4681:2c00::1) 16.821 ms
 2 [TRANSIT] 2001:5a8:657:21::f0:4 16.893 ms
 3 [TRANSIT] 2001:5a8:5:403f::f0:2 17.016 ms
 4 [TRANSIT] ae8.cr2.lsatca11.sonic.net (2001:5a8:5:403f::e4:a) 17.624 ms
 5 [TRANSIT] ae2.cr1.lsatca11.sonic.net (2001:5a8:5:403f::97:a) 17.757 ms
 6 [TRANSIT] ae1.cr4.lsatca11.sonic.net (2001:5a8:5:40b0::b) 17.886 ms
 7 [TRANSIT] ae0.cr4.snjsca11.sonic.net (2001:5a8:5:403f::96:a) 18.060 ms
 8 [TRANSIT] ae1.cr1.snjsca11.sonic.net (2001:5a8:5:4098::a) 18.312 ms
 9
10
11
12 [TRANSIT] 100.ae1.nrd1.equinix-sj.sonic.net (2001:5a8:5:403f::8a:a) 21.548 ms
13 [TRANSIT] 100.ae1.nrd1.equinix-sj.sonic.net (2001:5a8:5:403f::8a:a) 21.664 ms
14 [TRANSIT] 2001:4860:0:1::4571 21.952 ms
15 [TRANSIT] 2607:f8b0:85c1:1c0::1 22.225 ms
16 [TRANSIT] 2001:4860:0:1::1d7b 22.452 ms
17 [TRANSIT] pnsfoa-aa-in-x0e.1e100.net (2607:f8b0:4005:806::200e) 22.852 ms

Detected public IP: 192.184.164.83 (192-184-164-83.fiber.dynamic.sonic.net)
Detected ISP: AS46375 (AS-SONICTELECOM - Sonic Telecom LLC)
```

(v6 reverse DNS already works; hops show TRANSIT rather than ISP/DESTINATION because v6 ASN + STUN enrichment ships in the concurrent PR — classification degrades gracefully as designed.)

`FTR_TEST_IPV6=1 cargo test --test ipv6_integration -- --nocapture`:

```
running 3 tests
test test_live_ipv6_hostname_resolution_forced_v6 ... ok
live IPv6 trace: 16 hops, 9 intermediate, destination reached in 1.027459792s
   1 [TRANSIT] Some(2001:5a8:4681:2c00::1) Some(15.79175ms)
   2 [TRANSIT] Some(2001:5a8:657:21::f0:4) Some(15.8645ms)
   3 [TRANSIT] Some(2001:5a8:5:403f::f0:2) Some(16.071417ms)
   4 [TRANSIT] Some(2001:5a8:5:403f::e3:b) Some(16.686ms)
   5 [TRANSIT] Some(2001:5a8:5:403f::97:a) Some(16.784667ms)
   6 [UNKNOWN] None None
   7 [TRANSIT] Some(2001:5a8:5:403f::96:a) Some(18.210209ms)
   ...
  13 [TRANSIT] Some(2001:5a8:5:403f::8a:a) Some(21.904667ms)
  14 [TRANSIT] Some(2607:f8b0:85c1:100::1) Some(22.065959ms)
  15 [TRANSIT] Some(2001:4860:0:1::7d0d) Some(22.3865ms)
  16 [TRANSIT] Some(2001:4860:4860::8888) Some(22.608083ms)
test test_live_ipv6_trace_to_google_dns ... ok
test test_live_ipv6_trace_via_hostname ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.04s
```

Also verified live: `-4`/`-6` conflict rejected by clap; `-6 8.8.8.8` errors with family context ("8.8.8.8 is an IPv4 address but IPv6 was requested (-6)"); Auto still resolves dual-stack `google.com` to IPv4; `--json -6` emits canonical v6 addresses with the unchanged schema; an unprivileged trace to `::1` succeeds in one LAN-classified hop.

## Validation gates
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --keep-going -- -D warnings` ✅
- `cargo test` — full suite green (209 lib + all integration binaries) ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` ✅
- `cargo check --target x86_64-unknown-linux-gnu` ✅ (with ureq TLS features temporarily stripped per the established pattern; reverted, not committed)
- `cargo check --target x86_64-pc-windows-msvc` ✅ (only pre-existing lib-only dead-code warnings from the v4 codec)
- `cargo machete` ✅, `cargo audit` ✅

## API surface (additive only — 0.9.0 minor-safe)
- New: `PreferredFamily`, `TracerouteConfig.preferred_family` (`#[serde(default)]`), `TracerouteConfigBuilder::preferred_family`, `resolve_target_with_family`, `ProbeMode::DgramIcmpv6` (variant on `#[non_exhaustive]` enum).
- `libc` promoted from dev-dependency to dependency on macOS (production recvmsg cmsg + ICMP6_FILTER).

## Deferred (follow-up PRs)
- Linux (validated model in PR #38: UDP6 + `IPV6_RECVERR`, ping-socket kernel-assigned ids), Windows (`Icmp6SendEcho2`), BSD (raw ICMPv6) implementations.
- First-class zone-scoped targets (`fe80::1%en0`) — needs scope-id plumbing through config/factory; currently a clear typed error.
- Hop-level zone display in results (`ClassifiedHopInfo.addr` is `IpAddr`, which can't carry a scope; all observed hop responders are global scope).
- v6 ASN + STUN enrichment (concurrent PR) upgrades hop segments from TRANSIT to ISP/DESTINATION.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
