### PR TITLE
Prepare for v0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-17
+
+IPv6 support (closes #22): full-parity IPv6 traceroute with ASN, reverse
+DNS, and STUN enrichment — unprivileged on macOS and Linux, root on the
+BSDs. Windows IPv6 follows in a later release (`-6` there returns a typed
+`Ipv6NotSupported` error). All macOS/Linux kernel behavior was validated
+live before implementation (`docs/IPV6_DESIGN.md`).
+
 ### Added
-- Linux IPv6 traceroute (`-6`), mirroring the IPv4 mode ladder: unprivileged
-  UDP with `IPV6_RECVERR` (the default — works with stock sysctls, no root),
-  ICMPv6 ping sockets where `net.ipv4.ping_group_range` permits (the kernel
-  assigns the echo identifier; matching is per-socket by sequence), and raw
-  ICMPv6 as root/CAP_NET_RAW. Kernel behavior validated live on Ubuntu
-  24.04 / kernel 6.8 (`examples/spike_linux_v6.rs`, `docs/IPV6_DESIGN.md`)
-- FreeBSD/OpenBSD/NetBSD/DragonFly IPv6 traceroute (`-6`) via raw ICMPv6
-  sockets — root required, matching the BSDs' IPv4 behavior (they have no
-  unprivileged ICMP sockets of either family). The kernel computes the
-  ICMPv6 checksum on raw v6 sockets (RFC 3542 section 3.1; FreeBSD ip6(4))
-  and an `ICMP6_FILTER` (optname 18 in each BSD's `netinet6/in6.h`, bit
-  set = PASS) sheds noise on FreeBSD/OpenBSD. Exercised by CI's FreeBSD VM
-  (loopback v6; the VM has no external IPv6); OpenBSD/NetBSD/DragonFly are
-  best-effort and untested
+- IPv6 traceroute (`-6`, or automatic for v6-only targets) with per-hop
+  ASN, reverse DNS (`ip6.arpa`), and LAN/ISP/TRANSIT/DESTINATION segments
+- macOS: unprivileged DGRAM ICMPv6 — IPv6 traces need NO root on macOS
+  (unlike v4 raw); the kernel computes checksums, Time Exceeded arrives on
+  the normal receive path, and ftr filters by echo identifier in userspace
+  (Darwin does not demux ICMPv6 by id; `ICMP6_FILTER` constant 18 sheds
+  NDP noise)
+- Linux IPv6 mode ladder mirroring v4: unprivileged UDP with
+  `IPV6_RECVERR` (default — works with stock sysctls), ICMPv6 ping sockets
+  where `net.ipv4.ping_group_range` permits (kernel-assigned identifiers,
+  per-socket sequence matching), raw ICMPv6 as root. Validated live on
+  Ubuntu 24.04 / kernel 6.8 (`examples/spike_linux_v6.rs`)
+- FreeBSD/OpenBSD/NetBSD/DragonFly IPv6 via raw ICMPv6 (root, matching
+  their v4 posture); kernel checksums per RFC 3542 §3.1; exercised by CI's
+  FreeBSD VM on loopback (no external v6 on GitHub runners);
+  OpenBSD/NetBSD/DragonFly best-effort
+- `-4`/`-6` CLI flags and `PreferredFamily` config (Auto prefers v4 for
+  dual-stack targets; existing v4 behavior byte-identical)
+- IPv6 ASN lookups via Team Cymru `origin6` (nibble-reversed queries) with
+  offline short-circuits for reserved ranges (link-local, ULA, loopback,
+  documentation, v4-mapped defers to the v4 path)
+- STUN over IPv6 (XOR-MAPPED-ADDRESS family 0x02) and a both-families API:
+  `StunClient::{get_public_ip_v4, get_public_ip_v6, get_public_ips}`,
+  `Ftr::{get_public_ip_v6, get_public_ips}`, `PublicIps { v4, v6 }`
+  (parallel, never-throws); IPv6 ISP detection
+- ICMPv6 codec with embedded-identifier validation inside Time
+  Exceeded/Unreachable payloads; RFC 5952-canonical address output;
+  link-local `%zone` never stripped
+
+### Changed
+- **BREAKING**: `TracerouteConfig` is `#[non_exhaustive]` — construct via
+  `TracerouteConfig::builder()` or `Default`, not struct literals (a
+  `preferred_family` field was added; the builder path is unaffected)
 
 ### Fixed
+- HTTPS public-IP fallback panicked at runtime: ureq 3 defaults to a
+  Rustls TLS provider this crate does not compile in; the agent now
+  selects native-tls explicitly (all providers re-verified live)
 - IPv6 hops sharing the trace's local /64 (e.g. a home gateway answering
   from its global address inside the delegated prefix) now classify as LAN
-  instead of ISP, on all platforms; link-local and ULA hops stay LAN
+  instead of ISP; link-local and ULA hops stay LAN
+- Multi-origin Team Cymru payloads ("15169 36040 | ...") now yield the
+  first ASN instead of silently parsing as ASN 0
 
 ## [0.8.0] - 2026-07-16
 
@@ -574,7 +606,8 @@ let ftr = Ftr::with_caches(Some(asn_cache), None, None);
 - Clean, informative output with RTT measurements
 - Support for both hostnames and IP addresses
 
-[Unreleased]: https://github.com/dweekly/ftr/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/dweekly/ftr/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/dweekly/ftr/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/dweekly/ftr/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/dweekly/ftr/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/dweekly/ftr/compare/v0.5.0...v0.6.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,10 +73,10 @@ git config core.hooksPath .githooks
 
 | Platform | Socket Mode | Root Required | Notes |
 |----------|-------------|---------------|-------|
-| macOS    | Raw ICMP    | Yes           | Raw socket access |
-| Linux    | Raw/DGRAM/UDP | No (UDP via IP_RECVERR) | Unprivileged UDP traceroute supported |
-| FreeBSD/OpenBSD | Raw ICMP | Yes | Requires root for all operations |
-| Windows  | Win32 ICMP API | No | Uses IcmpSendEcho, not raw sockets |
+| macOS    | v4: Raw ICMP; v6: DGRAM ICMPv6 | v4: Yes; v6: No | v6 needs no root (Darwin unprivileged DGRAM ICMPv6) |
+| Linux    | Raw/DGRAM/UDP (v4+v6) | No (UDP via IP(V6)_RECVERR) | Unprivileged UDP traceroute both families |
+| FreeBSD/OpenBSD | Raw ICMP (v4+v6) | Yes | Requires root for all operations |
+| Windows  | Win32 ICMP API (v4 only) | No | Uses IcmpSendEcho; IPv6 planned (Icmp6SendEcho2) |
 
 ## CI Pipeline
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A fast, parallel traceroute implementation with automatic ASN lookup. Available 
 - **ASN Enrichment** - Automatic AS number and organization lookup with caching
 - **ISP Detection** - Identifies your ISP and classifies network segments
 - **Cross-Platform** - Works on Linux, macOS, Windows, FreeBSD, and OpenBSD
+- **IPv6** - Full IPv6 traceroute with v6 ASN/rDNS/STUN enrichment (`-6`); no root needed on macOS or Linux (Windows IPv6 planned)
 - **Multiple Protocols** - ICMP and UDP support with automatic fallback
 - **JSON Output** - Structured output for programmatic use
 - **Minimal Dependencies** - Efficient design with focus on performance
@@ -275,6 +276,7 @@ ftr example.com -m 20 -W 5000
 
 ### Options
 
+- `-4` / `-6` - Force IPv4 or IPv6 (default: auto — v4 preferred for dual-stack targets)
 - `-s, --start-ttl <START_TTL>` - Starting TTL value (default: 1)
 - `-m, --max-hops <MAX_HOPS>` - Maximum number of hops (default: 30)
 - `--probe-timeout-ms <MS>` - Timeout for individual probes in milliseconds (default: 1000)
@@ -326,11 +328,13 @@ Detected ISP from public IP 192.184.165.158: AS46375 (AS-SONICTELECOM, US)
 
 ### Privilege Requirements
 
-Privilege requirements vary by mode and platform:
-- **ICMP modes**: Root or ping_group_range configuration
-- **UDP mode**: 
-  - Linux: No privileges required (uses `IP_RECVERR`)
+Privilege requirements vary by mode, family, and platform:
+- **ICMP modes (IPv4)**: Root or ping_group_range configuration
+- **ICMPv6 on macOS**: No privileges required (unprivileged DGRAM ICMPv6)
+- **UDP mode**:
+  - Linux: No privileges required, IPv4 and IPv6 (`IP_RECVERR`/`IPV6_RECVERR`)
   - Other platforms: Root (needs raw socket for ICMP responses)
+- **BSDs**: Root for all traceroute operations, both families
 
 On Linux, you can enable DGRAM ICMP for non-root users:
 ```bash

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -105,29 +105,23 @@ before/after `cargo tree` counts in the body.
   network tests behind an env var and serialize them (SwiftFTR's
   `NetworkTestGate` pattern) instead of letting them flake CI.
 
-## IPv6 support (release train, closes issue #22)
+## IPv6: remaining platform + polish work
 
-Design and macOS kernel behavior are validated — see `docs/IPV6_DESIGN.md`
-(spikes in `examples/spike_*.rs`, PR #27). Key validated facts: unprivileged
-DGRAM ICMPv6 on macOS receives Time Exceeded directly (no root needed, unlike
-v4); Darwin does NOT demux v6 replies by echo identifier, so userspace id
-filtering is mandatory; `ICMP6_FILTER` works via raw `setsockopt` (constant 18
-from the macOS SDK, absent from libc/socket2); kernel computes ICMPv6
-checksums on DGRAM; STUN v6 and Cymru `origin6` ASN lookups verified live.
+macOS, Linux, and BSD IPv6 shipped in 0.9.0 (PRs #38–#43). Remaining:
 
-Remaining before integration:
-- Validate Linux (do ping sockets rewrite ids? filter semantics inverted?),
-  Windows (`Icmp6SendEcho2`), and BSD behavior — run the spikes there
-  (Parallels VMs / trogdor; GitHub cloud runners have no public IPv6, so live
-  v6 tests must be env-gated).
-- Root-mode RAW-vs-DGRAM comparison on macOS: `sudo cargo run --example
-  spike_traceroute6` (spike auto-detects euid 0).
-
-Bundle v6 trace + v6 ASN enrichment in one release (each is a half-feature
-alone); STUN v6 can trail. Contracts (from SwiftFTR, full list in the design
-doc): canonical `inet_ntop`-stable address strings; never strip `%zone` from
-link-local; single family-agnostic entry point; family in error *context*, not
-error type; `--preferred-family`/auto selection with `AI_V4MAPPED` for NAT64.
+- Windows IPv6 via `Icmp6SendEcho2`, mirroring the v4 `IcmpSendEcho2`
+  implementation. Validate live on the `nwx-dell-11` Tailscale box (local
+  Parallels is unreliable); also pay down the ~16 dead-code lints visible
+  only under a Windows-target `clippy --all-targets` (CI's clippy job runs
+  on Ubuntu and never compiles windows.rs — consider a windows-target
+  clippy cross-check in CI).
+- Open observations: router-originated ICMPv6 Time Exceeded on FreeBSD
+  remains unobserved first-hand (CI VM has no external v6); macOS root-mode
+  RAW-vs-DGRAM comparison (`sudo cargo run --release --example
+  spike_traceroute6`).
+- Polish: NAT64/DNS64 handling review (`AI_V4MAPPED`-style synthesis for
+  v4 literals on v6-only networks); first-class zone-scoped (`fe80::%if`)
+  targets; hop-level zone display.
 
 ## Feature ports from SwiftFTR (optional, by appetite)
 


### PR DESCRIPTION
Release-prep per docs/RELEASE_PROCESS.md: CHANGELOG consolidated into [0.9.0] - 2026-07-17 (IPv6 across macOS/Linux/BSD, unprivileged on the first two; the ureq TLS panic fix; LAN /64 classification; Cymru multi-origin fix; TracerouteConfig non_exhaustive noted as breaking), README/CLAUDE.md platform+privilege docs updated for v6, improvement plan curated to the remaining Windows/polish items. Version was bumped to 0.9.0 in #41.

Windows IPv6 intentionally ships later (typed `Ipv6NotSupported` on `-6` there today) — blocked on the nwx-dell-11 test box being online; it will be 0.10.0 or ride a patch train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)