### PR TITLE
feat: Windows IPv6 traceroute (Icmp6SendEcho2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Windows IPv6 traceroute via the IP Helper `Icmp6SendEcho2` API — the
+  last platform without v6. No elevation required (same as v4); `-6` now
+  works on all supported platforms. API behavior (unspecified `::` source
+  address, hop limit via `IP_OPTION_INFORMATION.Ttl`, reply layout, and
+  timeout semantics) was validated live in a Windows 11 VM before
+  implementation (`examples/spike_windows_v6.rs`, findings in
+  `docs/IPV6_DESIGN.md`), then confirmed with a live 17-hop external `-6`
+  trace with full ASN/rDNS/segment enrichment
+
+### Fixed
+- Paid down Windows-target lint debt: dead-code warnings in
+  `src/socket/icmp.rs`, `src/socket/windows.rs`, and the IPv6 spike
+  examples that only surface under
+  `cargo clippy --target x86_64-pc-windows-msvc --all-targets` (CI's
+  clippy job runs on Ubuntu and never sees them) are all resolved
+
 ## [0.9.0] - 2026-07-17
 
 IPv6 support (closes #22): full-parity IPv6 traceroute with ASN, reverse

--- a/docs/IPV6_DESIGN.md
+++ b/docs/IPV6_DESIGN.md
@@ -11,8 +11,11 @@ whenever kernel, library, or network behavior is in question.
 rustc 1.97.0, socket2 0.6, dual-stack network with live public IPv6
 (Sonic fiber); Linux — Ubuntu 24.04.4 LTS, kernel 6.8.0-124-generic (x86_64),
 glibc 2.39, rustc 1.97.1, same socket2, native IPv6 on the same Sonic fiber
-(see [Validated findings (Linux)](#validated-findings-linux)). Windows,
-FreeBSD, and OpenBSD behavior is **unvalidated** — see
+(see [Validated findings (Linux)](#validated-findings-linux)); Windows —
+Windows 11 ARM64 (build 26100), rustc 1.88.0, bridged network with native
+IPv6 on the same Sonic fiber (see
+[Validated findings (Windows)](#validated-findings-windows)).
+FreeBSD and OpenBSD behavior is **unvalidated** — see
 [Open questions](#open-questions-unvalidated-platforms).
 
 Run all spikes with:
@@ -23,6 +26,7 @@ cargo run --example spike_traceroute6
 cargo run --example spike_linux_v6     # Linux-only sections; stub main elsewhere
 cargo run --example spike_stun6
 cargo run --example spike_asn6
+cargo run --example spike_windows_v6   # Windows-only; stub main elsewhere
 ```
 
 ## Validated findings (macOS)
@@ -385,6 +389,70 @@ Notes:
 
   The spike auto-detects raw-socket availability and runs section [7].
 
+## Validated findings (Windows)
+
+Validated 2026-07-17 by `examples/spike_windows_v6.rs` in a Windows 11
+ARM64 VM (build 26100, Parallels bridged network, native IPv6 on Sonic
+fiber), then confirmed end to end with live `ftr -6` traces from the same
+VM. The implementation is `src/socket/windows_v6.rs`.
+
+### spike_windows_v6 — Icmp6SendEcho2 mechanics
+
+Everything the design hypothesized about the IP Helper v6 API holds, and
+the open questions are answered:
+
+1. **Source address**: `Icmp6SendEcho2` requires a source `SOCKADDR_IN6`
+   (unlike v4). Passing the unspecified address `::` with
+   `sin6_family = AF_INET6` works — the stack performs normal source
+   selection; no interface enumeration or `GetBestInterfaceEx` needed.
+2. **Hop limit**: the `IP_OPTION_INFORMATION.Ttl` field caps the outgoing
+   hop limit exactly as in v4. Expired probes come back as replies with
+   `Status = IP_HOP_LIMIT_EXCEEDED` (11013 — numerically identical to
+   v4's `IP_TTL_EXPIRED_TRANSIT`) carrying the router's address.
+3. **Reply layout** (spike printed sizes and hex dumps):
+   `ICMPV6_ECHO_REPLY_LH` is 36 bytes — packed 26-byte `IPV6_ADDRESS_EX`
+   at offset 0 (address `[u16; 8]` words at byte 6, **network byte
+   order**; `sin6_scope_id` at 22), 2 bytes padding, `Status` at 28,
+   `RoundTripTime` (ms) at 32. For Echo Replies the echoed request
+   payload sits directly after the struct at offset 36; Time Exceeded
+   replies do **not** echo the payload — the same asymmetry as v4, so
+   identifier/sequence verification is only possible on Echo Replies.
+4. **Async completion**: with an event handle, the event signals on reply
+   AND on timeout. `Icmp6ParseReplies` returns the reply count; on
+   timeout it returns 0 with `GetLastError() = IP_REQ_TIMED_OUT` (11010),
+   and the buffer's `Status` field also reads 11010. (The status field is
+   observably valid even before the parse call, as the v4 code assumes
+   for `IcmpSendEcho2`, but the v6 implementation calls
+   `Icmp6ParseReplies` per the API contract.)
+5. **No elevation**: all of the above from a normal user context (the
+   spike ran as SYSTEM via `prlctl exec`, but the shipped path is the
+   same unprivileged Win32 API as v4 — no raw sockets anywhere).
+
+Spike output (abridged; router addresses from the live Sonic path):
+
+```text
+[1] Icmp6CreateFile: OK
+[2] loopback ::1, full hop limit (sanity: Echo Reply path)
+  hop_limit=128: replies=1 raw_status_pre_parse=0
+    status=0 rtt_ms=0 from=::1 scope_id=0
+    struct sizes: ICMPV6_ECHO_REPLY_LH=36 IPV6_ADDRESS_EX=26
+[3] 2001:4860:4860::8888, hop limits 1..=4 (Time Exceeded path)
+  hop_limit=1: status=11013 rtt_ms=0 from=2001:5a8:4681:2c00::1
+  hop_limit=2: status=11013 rtt_ms=0 from=2001:5a8:657:21::f1:4
+  hop_limit=3: status=11013 rtt_ms=1 from=2001:5a8:5:403f::f0:2
+  hop_limit=4: status=11013 rtt_ms=7 from=2001:5a8:5:403f::e3:b
+[4] 2001:4860:4860::8888, hop limit 128 (destination Echo Reply)
+  hop_limit=128: status=0 rtt_ms=3 from=2001:4860:4860::8888
+    (echoed id/seq/payload verified at offset 36 in the hex dump)
+[5] unroutable 2001:db8::1, 50ms timeout (timeout path)
+  hop_limit=128: replies=0 (GetLastError after parse=11010)
+```
+
+A follow-up live `ftr -6 -v google.com` from the VM traced 17 hops
+through Sonic to `sfo07s17-in-x0e.1e100.net` with full ASN/rDNS/segment
+enrichment and v6 STUN public-IP detection, and `ftr 8.8.8.8` confirmed
+no v4 regression.
+
 ## Design decisions for stage-6 integration
 
 ### Socket mode per platform
@@ -393,7 +461,7 @@ Notes:
 |----------|-----------------|-------------|--------|
 | macOS | `IPV6`/`DGRAM`/`ICMPV6` | **No** | **Validated here** |
 | Linux | UDP + `IPV6_RECVERR` errqueue (unprivileged, works with default sysctls); `IPV6`/`DGRAM`/`ICMPV6` ping socket + `IPV6_RECVERR` where `ping_group_range` allows (disabled by default: `1 0`); raw ICMPv6 as root | **No** (UDP mode) | **Validated here** |
-| Windows | `Icmp6SendEcho2` (IP Helper) | No | Unvalidated |
+| Windows | `Icmp6SendEcho2` (IP Helper) | No | **Validated & implemented** (`src/socket/windows_v6.rs`; see [Validated findings (Windows)](#validated-findings-windows)) |
 | FreeBSD/OpenBSD | `IPV6`/`RAW`/`ICMPV6` | Yes | Implemented (`src/socket/bsd_v6.rs`); CI's FreeBSD VM is the test gate (loopback v6 only — the VM has no external IPv6). OpenBSD/NetBSD/DragonFly best-effort, untested |
 
 macOS gets a first-class unprivileged v6 mode — this is strictly better than
@@ -474,10 +542,6 @@ either model.
 Nothing below has been tested — these are hypotheses to validate by running
 the spikes on the target OS before implementing stage 6 there:
 
-- **Windows**: `Icmp6SendEcho2` should make traceroute mechanics moot (the
-  API handles TTL and reply matching), but hop-limit reporting and embedded
-  payload access need checking. Spikes currently print
-  "only implemented for macOS/Linux/FreeBSD" on Windows.
 - **FreeBSD**: the `ICMP6_FILTER` optname is 18
   (`#define ICMP6_FILTER 18` in `sys/netinet6/in6.h` of freebsd-src; the
   same line appears verbatim in OpenBSD, NetBSD, and DragonFly — all KAME

--- a/examples/spike_icmpv6_socket.rs
+++ b/examples/spike_icmpv6_socket.rs
@@ -22,6 +22,13 @@
 //! Findings are recorded in docs/IPV6_DESIGN.md. This spike stays in-repo as
 //! a permanent diagnostic: re-run it if kernel/OS behavior is in question.
 
+// On other platforms (e.g. Windows) only the stub main is compiled and the
+// constants below are unreferenced; keep target-specific clippy runs clean.
+#![cfg_attr(
+    not(any(target_os = "macos", target_os = "linux", target_os = "freebsd")),
+    allow(dead_code)
+)]
+
 /// ICMPv6 Echo Request message type (RFC 4443 section 4.1).
 const ICMPV6_ECHO_REQUEST: u8 = 128;
 /// ICMPv6 Echo Reply message type (RFC 4443 section 4.2).

--- a/examples/spike_traceroute6.rs
+++ b/examples/spike_traceroute6.rs
@@ -33,6 +33,13 @@
 //! Findings are recorded in docs/IPV6_DESIGN.md. This spike stays in-repo as
 //! a permanent diagnostic: re-run it if kernel/OS behavior is in question.
 
+// On other platforms (e.g. Windows) only the stub main is compiled and the
+// constants below are unreferenced; keep target-specific clippy runs clean.
+#![cfg_attr(
+    not(any(target_os = "macos", target_os = "linux", target_os = "freebsd")),
+    allow(dead_code)
+)]
+
 /// ICMPv6 message types (RFC 4443).
 const ICMPV6_DEST_UNREACHABLE: u8 = 1;
 /// Time Exceeded (RFC 4443 section 3.3).

--- a/examples/spike_windows_v6.rs
+++ b/examples/spike_windows_v6.rs
@@ -1,0 +1,197 @@
+//! Spike: Windows `Icmp6SendEcho2` behavior for IPv6 traceroute.
+//!
+//! Companion to `spike_traceroute6` (macOS) and `spike_linux_v6`; this one
+//! answers the Windows questions from docs/IPV6_DESIGN.md before
+//! `src/socket/windows_v6.rs` relies on them:
+//!
+//! 1. Does `Icmp6SendEcho2` accept an unspecified (`::`) source address
+//!    with `sin6_family = AF_INET6`, letting the stack pick the source
+//!    (the API signature *requires* a source sockaddr, unlike v4)?
+//! 2. Does the `IP_OPTION_INFORMATION.Ttl` field set the outgoing hop
+//!    limit, producing Time Exceeded from intermediate routers with
+//!    `Status = IP_HOP_LIMIT_EXCEEDED` (11013)?
+//! 3. In async (event) mode, is `Icmp6ParseReplies` required, and what is
+//!    the parsed buffer layout: is `ICMPV6_ECHO_REPLY_LH` at offset 0, are
+//!    the `IPV6_ADDRESS_EX.sin6_addr` words in network byte order, and
+//!    where does the echoed request payload land for an Echo Reply?
+//! 4. On timeout, does `Icmp6ParseReplies` return 0 with
+//!    `GetLastError() = IP_REQ_TIMED_OUT` (11010), or 1 reply carrying
+//!    that status?
+//!
+//! Run (Windows): `cargo run --example spike_windows_v6 [target6]`
+//! (default target is Google Public DNS, 2001:4860:4860::8888).
+//!
+//! Findings are recorded in docs/IPV6_DESIGN.md. This spike stays in-repo
+//! as a permanent diagnostic: re-run it if OS behavior is in question.
+
+#[cfg(target_os = "windows")]
+mod spike {
+    use std::ffi::c_void;
+    use std::mem;
+    use std::net::Ipv6Addr;
+    use std::ptr;
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, ERROR_IO_PENDING, GetLastError, WAIT_OBJECT_0, WAIT_TIMEOUT,
+    };
+    use windows_sys::Win32::NetworkManagement::IpHelper::{
+        ICMPV6_ECHO_REPLY_LH, IP_OPTION_INFORMATION, Icmp6CreateFile, Icmp6ParseReplies,
+        Icmp6SendEcho2, IcmpCloseHandle,
+    };
+    use windows_sys::Win32::Networking::WinSock::{AF_INET6, SOCKADDR_IN6};
+    use windows_sys::Win32::System::Threading::{CreateEventW, WaitForSingleObject};
+
+    fn sockaddr6(addr: Ipv6Addr, scope_id: u32) -> SOCKADDR_IN6 {
+        let mut sa: SOCKADDR_IN6 = unsafe { mem::zeroed() };
+        sa.sin6_family = AF_INET6;
+        sa.sin6_addr.u.Byte = addr.octets();
+        sa.Anonymous.sin6_scope_id = scope_id;
+        sa
+    }
+
+    fn dump(buf: &[u8], n: usize) {
+        for (i, chunk) in buf[..n.min(buf.len())].chunks(16).enumerate() {
+            let hex: Vec<String> = chunk.iter().map(|b| format!("{b:02x}")).collect();
+            println!("      {:04x}: {}", i * 16, hex.join(" "));
+        }
+    }
+
+    /// One probe: send with the given hop limit, wait on the event, parse.
+    fn probe(handle: *mut c_void, dest: Ipv6Addr, hop_limit: u8, timeout_ms: u32) {
+        let source = sockaddr6(Ipv6Addr::UNSPECIFIED, 0);
+        let dest_sa = sockaddr6(dest, 0);
+
+        let event = unsafe { CreateEventW(ptr::null(), 1, 0, ptr::null()) };
+        assert!(!event.is_null(), "CreateEventW failed");
+
+        // Identifier+sequence payload, same shape as the v4 implementation.
+        let mut send_data = Vec::with_capacity(32);
+        send_data.extend_from_slice(&(std::process::id() as u16).to_be_bytes());
+        send_data.extend_from_slice(&0x1234u16.to_be_bytes());
+        send_data.extend_from_slice(b"ftr-windows-v6-spike");
+        send_data.resize(32, 0);
+
+        let reply_size = mem::size_of::<ICMPV6_ECHO_REPLY_LH>() + send_data.len() + 8;
+        let mut reply_buffer = vec![0u8; reply_size];
+
+        let options = IP_OPTION_INFORMATION {
+            Ttl: hop_limit,
+            Tos: 0,
+            Flags: 0,
+            OptionsSize: 0,
+            OptionsData: ptr::null_mut(),
+        };
+
+        let result = unsafe {
+            Icmp6SendEcho2(
+                handle,
+                event,
+                None,
+                ptr::null(),
+                &source,
+                &dest_sa,
+                send_data.as_ptr() as *const c_void,
+                send_data.len() as u16,
+                &options,
+                reply_buffer.as_mut_ptr() as *mut c_void,
+                reply_size as u32,
+                timeout_ms,
+            )
+        };
+        if result == 0 {
+            let err = unsafe { GetLastError() };
+            if err != ERROR_IO_PENDING {
+                println!("  hop_limit={hop_limit}: Icmp6SendEcho2 FAILED, GetLastError={err}");
+                unsafe { CloseHandle(event) };
+                return;
+            }
+        }
+
+        let wait = unsafe { WaitForSingleObject(event, timeout_ms + 1000) };
+        if wait == WAIT_TIMEOUT {
+            println!("  hop_limit={hop_limit}: event never signaled (WAIT_TIMEOUT)");
+            unsafe { CloseHandle(event) };
+            return;
+        }
+        assert_eq!(wait, WAIT_OBJECT_0, "unexpected wait result {wait}");
+
+        // Read the struct BEFORE Icmp6ParseReplies to see whether parsing
+        // is actually required in async mode (v4 skips IcmpParseReplies).
+        let raw_status = u32::from_ne_bytes(reply_buffer[28..32].try_into().expect("4 bytes"));
+
+        let parsed = unsafe {
+            Icmp6ParseReplies(reply_buffer.as_mut_ptr() as *mut c_void, reply_size as u32)
+        };
+        let parse_err = unsafe { GetLastError() };
+
+        println!(
+            "  hop_limit={hop_limit}: replies={parsed} (GetLastError after parse={parse_err}) raw_status_pre_parse={raw_status}"
+        );
+        if parsed >= 1 {
+            // SAFETY: buffer is at least reply_size and the API filled it.
+            let reply = unsafe { &*(reply_buffer.as_ptr() as *const ICMPV6_ECHO_REPLY_LH) };
+            let addr_ex = reply.Address;
+            let words = addr_ex.sin6_addr;
+            let mut octets = [0u8; 16];
+            for (i, w) in words.iter().enumerate() {
+                octets[i * 2..i * 2 + 2].copy_from_slice(&w.to_ne_bytes());
+            }
+            let from = Ipv6Addr::from(octets);
+            let scope = addr_ex.sin6_scope_id;
+            let status = reply.Status;
+            let rtt = reply.RoundTripTime;
+            println!("    status={status} rtt_ms={rtt} from={from} scope_id={scope}");
+            println!(
+                "    struct sizes: ICMPV6_ECHO_REPLY_LH={} IPV6_ADDRESS_EX={}",
+                mem::size_of::<ICMPV6_ECHO_REPLY_LH>(),
+                mem::size_of::<windows_sys::Win32::NetworkManagement::IpHelper::IPV6_ADDRESS_EX>()
+            );
+            println!("    buffer hex (first 64B; echoed data offset check):");
+            dump(&reply_buffer, 64);
+        }
+        unsafe { CloseHandle(event) };
+    }
+
+    pub fn main() {
+        let target: Ipv6Addr = std::env::args()
+            .nth(1)
+            .unwrap_or_else(|| "2001:4860:4860::8888".to_string())
+            .parse()
+            .expect("target must be an IPv6 address");
+
+        let handle = unsafe { Icmp6CreateFile() };
+        assert!(!handle.is_null(), "Icmp6CreateFile failed");
+        println!("[1] Icmp6CreateFile: OK");
+
+        println!("[2] loopback ::1, full hop limit (sanity: Echo Reply path)");
+        probe(handle, Ipv6Addr::LOCALHOST, 128, 2000);
+
+        println!("[3] {target}, hop limits 1..=4 (Time Exceeded path)");
+        for hl in 1..=4 {
+            probe(handle, target, hl, 2000);
+        }
+
+        println!("[4] {target}, hop limit 128 (destination Echo Reply)");
+        probe(handle, target, 128, 2000);
+
+        println!("[5] unroutable 2001:db8::1, 50ms timeout (timeout path)");
+        probe(
+            handle,
+            Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1),
+            128,
+            50,
+        );
+
+        unsafe { IcmpCloseHandle(handle) };
+        println!("done");
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn main() {
+    spike::main();
+}
+
+#[cfg(not(target_os = "windows"))]
+fn main() {
+    eprintln!("spike_windows_v6 only runs on Windows (see docs/IPV6_DESIGN.md)");
+}

--- a/src/socket/factory.rs
+++ b/src/socket/factory.rs
@@ -188,10 +188,29 @@ pub async fn create_probe_socket_with_options_and_verbose(
                 Ok(Box::new(socket))
             }
 
-            // Windows IPv6 probing is planned (see docs/IPV6_DESIGN.md
-            // open questions); until its behavior is validated, report
-            // the typed error.
+            #[cfg(target_os = "windows")]
+            {
+                let _ = socket_mode;
+                // The Win32 ICMP API is the only probing mechanism ftr
+                // uses on Windows, for v6 as for v4.
+                if let Some(ProbeProtocol::Udp) = protocol {
+                    return Err(TracerouteError::NotImplemented {
+                        feature: "UDP IPv6 traceroute on Windows".to_string(),
+                    });
+                }
+                use super::windows_v6::WindowsAsyncIcmpV6Socket;
+                let socket =
+                    WindowsAsyncIcmpV6Socket::new_with_config_and_verbose(timing_config, verbose)?;
+
+                if verbose > 0 {
+                    eprintln!("Using Windows ICMPv6 API mode for traceroute");
+                }
+
+                Ok(Box::new(socket))
+            }
+
             #[cfg(not(any(
+                target_os = "windows",
                 target_os = "macos",
                 target_os = "linux",
                 target_os = "freebsd",

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -15,10 +15,15 @@ pub(crate) mod bsd;
 ))]
 pub(crate) mod bsd_v6;
 pub(crate) mod factory;
+// The v4 ICMP codec's parse/build helpers are only consumed by the Unix
+// socket paths; Windows probes through the Win32 ICMP API, which parses
+// replies itself, so there they are compiled for their unit tests only.
+#[cfg_attr(target_os = "windows", allow(dead_code))]
 pub(crate) mod icmp;
 // The ICMPv6 codec is platform-neutral and its unit tests run everywhere,
-// but only the macOS, Linux, and BSD socket paths consume it so far
-// (Windows v6 support is planned) — silence dead_code elsewhere until then.
+// but only the macOS, Linux, and BSD socket paths consume it — the Windows
+// v6 path doesn't (the Icmp6SendEcho2 API parses replies itself), so
+// silence dead_code elsewhere.
 #[cfg_attr(
     not(any(
         target_os = "macos",
@@ -43,20 +48,23 @@ pub mod traits;
 pub mod utils;
 #[cfg(target_os = "windows")]
 pub(crate) mod windows;
+#[cfg(target_os = "windows")]
+pub(crate) mod windows_v6;
 
 use serde::{Deserialize, Serialize};
 
 /// IP version to use for probing
 ///
-/// IPv4 is supported on all platforms. IPv6 probing is currently supported
-/// on macOS (unprivileged DGRAM ICMPv6), Linux (unprivileged UDP with
+/// IPv4 is supported on all platforms. IPv6 probing is supported on macOS
+/// (unprivileged DGRAM ICMPv6), Linux (unprivileged UDP with
 /// `IPV6_RECVERR` by default, ICMPv6 ping sockets where
-/// `net.ipv4.ping_group_range` permits, raw ICMPv6 as root), and the BSDs
+/// `net.ipv4.ping_group_range` permits, raw ICMPv6 as root), Windows
+/// (`Icmp6SendEcho2`, no elevation required), and the BSDs
 /// (raw ICMPv6, root required — exercised by CI's FreeBSD VM; OpenBSD/
-/// NetBSD/DragonFly are best-effort and untested); other
-/// platforms return
+/// NetBSD/DragonFly are best-effort and untested); any remaining platform
+/// returns
 /// [`TracerouteError::Ipv6NotSupported`](crate::TracerouteError::Ipv6NotSupported)
-/// for IPv6 targets until their implementations land.
+/// for IPv6 targets.
 ///
 /// This enum is `#[non_exhaustive]` so downstream matches must include a
 /// wildcard arm.

--- a/src/socket/windows.rs
+++ b/src/socket/windows.rs
@@ -70,11 +70,6 @@ pub struct WindowsAsyncIcmpSocket {
 }
 
 impl WindowsAsyncIcmpSocket {
-    /// Create a new Windows async ICMP socket
-    pub fn new_with_config(timing_config: TimingConfig) -> Result<Self, TracerouteError> {
-        Self::new_with_config_and_verbose(timing_config, 0)
-    }
-
     /// Create a new Windows async ICMP socket with an explicit verbosity
     /// level (replaces the former FTR_VERBOSE environment lookup)
     pub fn new_with_config_and_verbose(

--- a/src/socket/windows_v6.rs
+++ b/src/socket/windows_v6.rs
@@ -1,0 +1,579 @@
+//! Windows async ICMPv6 socket using Tokio
+//!
+//! IPv6 counterpart of [`super::windows`]: echo requests go through the
+//! IP Helper `Icmp6CreateFile`/`Icmp6SendEcho2`/`Icmp6ParseReplies` API
+//! with Tokio's async primitives for immediate response notification. No
+//! elevation is required — the API works from a normal user context, same
+//! as v4.
+//!
+//! All behavior below was validated live in a Windows 11 (ARM64) VM by
+//! `examples/spike_windows_v6.rs` (findings recorded in
+//! `docs/IPV6_DESIGN.md`):
+//!
+//! - Passing the unspecified address `::` (with `sin6_family = AF_INET6`)
+//!   as the required source sockaddr lets the stack perform normal source
+//!   address selection — no interface enumeration needed.
+//! - The `IP_OPTION_INFORMATION.Ttl` field sets the outgoing hop limit,
+//!   exactly like v4, and intermediate routers surface as replies with
+//!   `Status = IP_HOP_LIMIT_EXCEEDED` (11013).
+//! - The reply buffer holds an `ICMPV6_ECHO_REPLY_LH` (36 bytes: packed
+//!   26-byte `IPV6_ADDRESS_EX`, 2 bytes padding, `Status` at offset 28,
+//!   `RoundTripTime` at offset 32) followed by the echoed request payload
+//!   for Echo Replies. Time Exceeded replies do not echo the payload —
+//!   same asymmetry as v4.
+//! - `IPV6_ADDRESS_EX.sin6_addr` is `[u16; 8]` whose words carry the
+//!   address bytes in network order.
+//! - On timeout the event still signals; `Icmp6ParseReplies` returns 0
+//!   and the status field reads `IP_REQ_TIMED_OUT` (11010).
+
+use crate::TimingConfig;
+use crate::probe::{ProbeInfo, ProbeResponse};
+use crate::socket::traits::{ProbeMode, ProbeSocket};
+use crate::traceroute::TracerouteError;
+use std::ffi::c_void;
+use std::future::Future;
+use std::mem;
+use std::net::{IpAddr, Ipv6Addr};
+use std::pin::Pin;
+use std::ptr;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::sync::oneshot;
+use windows_sys::Win32::Foundation::{
+    CloseHandle, ERROR_IO_PENDING, GetLastError, HANDLE, WAIT_OBJECT_0,
+};
+// Unlike super::windows (which predates windows-sys exporting them), the
+// status codes come straight from windows-sys: IP_REQ_TIMED_OUT = 11010,
+// IP_GENERAL_FAILURE = 11050, IP_SUCCESS = 0 (ipexport.h values).
+use windows_sys::Win32::NetworkManagement::IpHelper::{
+    ICMPV6_ECHO_REPLY_LH, IP_GENERAL_FAILURE, IP_OPTION_INFORMATION, IP_REQ_TIMED_OUT, IP_SUCCESS,
+    Icmp6CreateFile, Icmp6ParseReplies, Icmp6SendEcho2, IcmpCloseHandle,
+};
+use windows_sys::Win32::Networking::WinSock::{AF_INET6, SOCKADDR_IN6};
+use windows_sys::Win32::System::Threading::{CreateEventW, WaitForSingleObject};
+
+/// Windows async ICMPv6 socket implementation
+///
+/// Uses the Windows `Icmp6SendEcho2` API for sending ICMPv6 echo requests.
+/// The async design — event handle per probe, `spawn_blocking` waiter,
+/// Tokio timeout with a Windows-side buffer — mirrors
+/// [`super::windows::WindowsAsyncIcmpSocket`]; see that type and
+/// `docs/WINDOWS_ASYNC_FINDINGS.md` for why this shape won.
+pub struct WindowsAsyncIcmpV6Socket {
+    icmp_handle: HANDLE,
+    destination_reached: Arc<Mutex<bool>>,
+    pending_count: Arc<Mutex<usize>>,
+    timing_config: TimingConfig,
+    verbose: u8,
+}
+
+/// Build a `SOCKADDR_IN6` for `Icmp6SendEcho2` from an address.
+///
+/// `scope_id` stays 0: `Ipv6Addr` carries no zone, and the spike's global
+/// unicast targets needed none. Link-local targets would need the caller
+/// to plumb a zone through — not supported yet on any ftr platform.
+fn sockaddr_in6(addr: Ipv6Addr) -> SOCKADDR_IN6 {
+    let mut sa: SOCKADDR_IN6 = unsafe { mem::zeroed() };
+    sa.sin6_family = AF_INET6;
+    sa.sin6_addr.u.Byte = addr.octets();
+    sa
+}
+
+/// Reconstruct the reply source address from `IPV6_ADDRESS_EX.sin6_addr`.
+///
+/// The field is `[u16; 8]` holding the 16 address bytes in network order
+/// (spike-verified against known router addresses), so re-serializing each
+/// word with native endianness recovers the wire bytes on any host.
+fn ipv6_from_reply_words(words: [u16; 8]) -> Ipv6Addr {
+    let mut octets = [0u8; 16];
+    for (i, w) in words.iter().enumerate() {
+        octets[i * 2..i * 2 + 2].copy_from_slice(&w.to_ne_bytes());
+    }
+    Ipv6Addr::from(octets)
+}
+
+/// Parse one reply buffer into a `ProbeResponse` (no socket state — the
+/// caller updates `destination_reached`). `elapsed` is the locally
+/// measured round-trip, used when the API reports a sub-millisecond 0.
+fn parse_reply(
+    buffer: &[u8],
+    sequence: u16,
+    ttl: u8,
+    elapsed: Duration,
+) -> Result<ProbeResponse, TracerouteError> {
+    if buffer.len() < mem::size_of::<ICMPV6_ECHO_REPLY_LH>() {
+        return Err(TracerouteError::SocketError(
+            "ICMPv6 response buffer too small".to_string(),
+        ));
+    }
+
+    // SAFETY: length checked above; read_unaligned tolerates the Vec<u8>
+    // buffer's 1-byte alignment (the struct wants 4).
+    let reply = unsafe { ptr::read_unaligned(buffer.as_ptr() as *const ICMPV6_ECHO_REPLY_LH) };
+
+    // Echo Replies (destination reached) echo our request payload right
+    // after the reply struct (spike-verified offset); Time Exceeded and
+    // other ICMPv6 errors don't echo it back — same asymmetry as v4.
+    if reply.Status == IP_SUCCESS {
+        let data_offset = mem::size_of::<ICMPV6_ECHO_REPLY_LH>();
+        let data = &buffer[data_offset..];
+        if data.len() >= 4 {
+            let identifier = u16::from_be_bytes([data[0], data[1]]);
+            let recv_sequence = u16::from_be_bytes([data[2], data[3]]);
+
+            let expected_identifier = std::process::id() as u16;
+            if identifier != expected_identifier || recv_sequence != sequence {
+                return Err(TracerouteError::SocketError(format!(
+                    "ICMPv6 response mismatch: expected id={}/seq={}, got id={}/seq={}",
+                    expected_identifier, sequence, identifier, recv_sequence
+                )));
+            }
+        }
+    }
+
+    if reply.Status == IP_REQ_TIMED_OUT || reply.Status == IP_GENERAL_FAILURE {
+        return Ok(ProbeResponse {
+            from_addr: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+            sequence,
+            ttl,
+            rtt: elapsed,
+            received_at: Instant::now(),
+            is_destination: false,
+            is_timeout: true,
+        });
+    }
+
+    let from_addr = IpAddr::V6(ipv6_from_reply_words(reply.Address.sin6_addr));
+    let is_destination = reply.Status == IP_SUCCESS;
+
+    // Use the Windows API's RoundTripTime (milliseconds); it reads 0 for
+    // sub-millisecond responses, where our own elapsed time is better.
+    let rtt = if reply.RoundTripTime > 0 {
+        Duration::from_millis(reply.RoundTripTime as u64)
+    } else {
+        elapsed
+    };
+
+    Ok(ProbeResponse {
+        from_addr,
+        sequence,
+        ttl,
+        rtt,
+        received_at: Instant::now(),
+        is_destination,
+        is_timeout: false,
+    })
+}
+
+impl WindowsAsyncIcmpV6Socket {
+    /// Create a new Windows async ICMPv6 socket with an explicit
+    /// verbosity level
+    pub fn new_with_config_and_verbose(
+        timing_config: TimingConfig,
+        verbose: u8,
+    ) -> Result<Self, TracerouteError> {
+        let icmp_handle = unsafe { Icmp6CreateFile() };
+        if icmp_handle.is_null() {
+            return Err(TracerouteError::SocketError(
+                "Failed to create ICMPv6 handle".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            icmp_handle,
+            destination_reached: Arc::new(Mutex::new(false)),
+            pending_count: Arc::new(Mutex::new(0)),
+            timing_config,
+            verbose,
+        })
+    }
+
+    /// Windows-side timeout: user timeout plus a buffer so the Tokio
+    /// timeout always fires first (same race-avoidance as v4 — see
+    /// `docs/WINDOWS_ASYNC_FINDINGS.md`), floored at the empirical
+    /// minimum below which the Windows ICMP API misbehaves.
+    fn windows_timeout_ms(&self) -> u32 {
+        let user_timeout_ms = self.timing_config.socket_read_timeout.as_millis() as u32;
+        let windows_timeout =
+            user_timeout_ms + crate::config::timing::WINDOWS_ICMP_TIMEOUT_BUFFER_MS;
+        windows_timeout.max(crate::config::timing::WINDOWS_ICMP_MIN_TOTAL_TIMEOUT_MS)
+    }
+}
+
+impl ProbeSocket for WindowsAsyncIcmpV6Socket {
+    fn mode(&self) -> ProbeMode {
+        ProbeMode::WindowsIcmp
+    }
+
+    fn send_probe_and_recv(
+        &self,
+        dest: IpAddr,
+        probe: ProbeInfo,
+    ) -> Pin<Box<dyn Future<Output = Result<ProbeResponse, TracerouteError>> + Send + '_>> {
+        Box::pin(async move {
+            let dest_addr = match dest {
+                IpAddr::V6(addr) => addr,
+                IpAddr::V4(_) => {
+                    return Err(TracerouteError::SocketError(
+                        "ICMPv6 socket cannot probe an IPv4 destination".to_string(),
+                    ));
+                }
+            };
+
+            {
+                let mut count = self
+                    .pending_count
+                    .lock()
+                    .expect("Failed to acquire pending_count lock");
+                *count += 1;
+            }
+
+            // Create event for this probe
+            let event = unsafe { CreateEventW(ptr::null(), 1, 0, ptr::null()) };
+            if event.is_null() {
+                let mut count = self
+                    .pending_count
+                    .lock()
+                    .expect("Failed to acquire pending_count lock");
+                *count -= 1;
+                return Err(TracerouteError::SocketError(
+                    "Failed to create event".to_string(),
+                ));
+            }
+
+            // Identifier + sequence payload, same shape as v4 (Echo
+            // Replies echo it back; used to reject foreign replies).
+            let identifier = std::process::id() as u16;
+            let mut send_data = Vec::with_capacity(32);
+            send_data.extend_from_slice(&identifier.to_be_bytes());
+            send_data.extend_from_slice(&probe.sequence.to_be_bytes());
+            send_data.extend_from_slice(b"ftr-windows-padding");
+            send_data.resize(32, 0);
+
+            // Reply buffer sized per the Icmp6SendEcho2 contract: one
+            // ICMPV6_ECHO_REPLY plus the echoed data plus 8 bytes for an
+            // ICMP error message. Boxed for a stable location across the
+            // await.
+            let reply_size = mem::size_of::<ICMPV6_ECHO_REPLY_LH>() + send_data.len() + 8;
+            let mut reply_buffer = Box::pin(vec![0u8; reply_size]);
+            let reply_ptr = reply_buffer.as_mut_ptr() as *mut c_void;
+
+            let sent_at = Instant::now();
+
+            // Source `::` = let the stack pick (spike-validated);
+            // destination carries the target.
+            let source = sockaddr_in6(Ipv6Addr::UNSPECIFIED);
+            let dest_sa = sockaddr_in6(dest_addr);
+
+            // Send in its own scope so options is dropped before the await
+            let send_result = {
+                let options = IP_OPTION_INFORMATION {
+                    Ttl: probe.ttl,
+                    Tos: 0,
+                    Flags: 0,
+                    OptionsSize: 0,
+                    OptionsData: ptr::null_mut(),
+                };
+
+                let result = unsafe {
+                    Icmp6SendEcho2(
+                        self.icmp_handle,
+                        event,
+                        None,        // No APC routine
+                        ptr::null(), // No APC context
+                        &source,
+                        &dest_sa,
+                        send_data.as_ptr() as *const c_void,
+                        send_data.len() as u16,
+                        &options as *const IP_OPTION_INFORMATION,
+                        reply_ptr,
+                        reply_size as u32,
+                        self.windows_timeout_ms(),
+                    )
+                };
+
+                if result == 0 {
+                    let error = unsafe { GetLastError() };
+                    if error != ERROR_IO_PENDING {
+                        Err(error)
+                    } else {
+                        Ok(())
+                    }
+                } else {
+                    Ok(())
+                }
+            };
+
+            if let Err(error) = send_result {
+                unsafe { CloseHandle(event) };
+                let mut count = self
+                    .pending_count
+                    .lock()
+                    .expect("Failed to acquire pending_count lock");
+                *count -= 1;
+                return Err(TracerouteError::SocketError(format!(
+                    "Icmp6SendEcho2 failed: {}",
+                    error
+                )));
+            }
+
+            // Oneshot channel + spawn_blocking waiter, as in v4. The
+            // reply buffer moves into the task so it stays alive even if
+            // our Tokio timeout abandons the wait.
+            let (tx, rx) = oneshot::channel();
+            let event_handle = event as usize; // usize for Send safety
+            let pending_count = Arc::clone(&self.pending_count);
+
+            let wait_handle = tokio::task::spawn_blocking(move || {
+                let event = event_handle as HANDLE;
+                let result = unsafe {
+                    // INFINITE: the Tokio timeout owns cancellation; the
+                    // Windows-side timeout (set above) signals the event.
+                    WaitForSingleObject(event, 0xFFFFFFFF)
+                };
+                unsafe { CloseHandle(event) };
+
+                let mut count = pending_count
+                    .lock()
+                    .expect("Failed to acquire pending_count lock");
+                *count = count.saturating_sub(1);
+
+                if result == WAIT_OBJECT_0 {
+                    // Async completions must go through Icmp6ParseReplies
+                    // (per the API contract; spike-confirmed it fixes up
+                    // the buffer and reports the reply count — 0 means
+                    // timeout/error, with the status also readable in the
+                    // buffer's Status field).
+                    let mut buffer = reply_buffer;
+                    let parsed = unsafe {
+                        Icmp6ParseReplies(buffer.as_mut_ptr() as *mut c_void, reply_size as u32)
+                    };
+                    tx.send(Ok((buffer, parsed))).ok();
+                } else {
+                    tx.send(Err(TracerouteError::SocketError(
+                        "Event wait failed or timed out".to_string(),
+                    )))
+                    .ok();
+                }
+            });
+
+            let timeout_duration = self.timing_config.socket_read_timeout;
+
+            if self.verbose >= 3 {
+                eprintln!(
+                    "[TIMEOUT] ICMPv6 probe seq={} ttl={}: User timeout={}ms, Windows timeout={}ms",
+                    probe.sequence,
+                    probe.ttl,
+                    timeout_duration.as_millis(),
+                    self.windows_timeout_ms()
+                );
+            }
+
+            match tokio::time::timeout(timeout_duration, rx).await {
+                Ok(Ok(Ok((reply_buffer, parsed)))) => {
+                    if parsed == 0 {
+                        // Windows-side timeout or send error surfaced via
+                        // parse (status IP_REQ_TIMED_OUT in the buffer)
+                        return Ok(ProbeResponse {
+                            from_addr: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+                            sequence: probe.sequence,
+                            ttl: probe.ttl,
+                            rtt: sent_at.elapsed(),
+                            received_at: Instant::now(),
+                            is_destination: false,
+                            is_timeout: true,
+                        });
+                    }
+                    let response =
+                        parse_reply(&reply_buffer, probe.sequence, probe.ttl, sent_at.elapsed())?;
+                    if response.is_destination {
+                        *self
+                            .destination_reached
+                            .lock()
+                            .expect("Failed to acquire destination_reached lock") = true;
+                    }
+                    Ok(response)
+                }
+                Ok(Ok(Err(e))) => Err(TracerouteError::SocketError(format!(
+                    "Event wait error: {}",
+                    e
+                ))),
+                Ok(Err(_)) => Err(TracerouteError::SocketError(
+                    "Event wait cancelled".to_string(),
+                )),
+                Err(_) => {
+                    // Tokio timeout fired first (guaranteed by the
+                    // Windows-side buffer); let the blocking task finish
+                    // in the background rather than cancelling it.
+                    drop(wait_handle);
+
+                    Ok(ProbeResponse {
+                        from_addr: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+                        sequence: probe.sequence,
+                        ttl: probe.ttl,
+                        rtt: timeout_duration,
+                        received_at: Instant::now(),
+                        is_destination: false,
+                        is_timeout: true,
+                    })
+                }
+            }
+        })
+    }
+
+    fn destination_reached(&self) -> bool {
+        *self
+            .destination_reached
+            .lock()
+            .expect("Failed to acquire destination_reached lock")
+    }
+
+    fn pending_count(&self) -> usize {
+        *self
+            .pending_count
+            .lock()
+            .expect("Failed to acquire pending_count lock")
+    }
+}
+
+impl Drop for WindowsAsyncIcmpV6Socket {
+    fn drop(&mut self) {
+        if !self.icmp_handle.is_null() {
+            let pending = *self
+                .pending_count
+                .lock()
+                .expect("Failed to acquire pending_count lock");
+            if pending == 0 {
+                // With pending operations we skip IcmpCloseHandle — it
+                // blocks until they complete (600ms+); Windows reclaims
+                // the handle at process exit. Same optimization as v4.
+                unsafe { IcmpCloseHandle(self.icmp_handle) };
+            }
+        }
+    }
+}
+
+// Safety: the ICMP handle is only used for Icmp6SendEcho2 calls, which the
+// IP Helper API allows from any thread; shared state is behind mutexes.
+unsafe impl Send for WindowsAsyncIcmpV6Socket {}
+unsafe impl Sync for WindowsAsyncIcmpV6Socket {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use windows_sys::Win32::NetworkManagement::IpHelper::IP_HOP_LIMIT_EXCEEDED;
+
+    /// Build a synthetic reply buffer with the spike-verified layout:
+    /// packed IPV6_ADDRESS_EX at 0 (address words at byte 6, network
+    /// order), Status at 28, RoundTripTime at 32, echoed data at 36.
+    fn synthetic_reply(addr: Ipv6Addr, status: u32, rtt_ms: u32, echoed: &[u8]) -> Vec<u8> {
+        let mut buf = vec![0u8; mem::size_of::<ICMPV6_ECHO_REPLY_LH>() + echoed.len()];
+        buf[6..22].copy_from_slice(&addr.octets());
+        buf[28..32].copy_from_slice(&status.to_ne_bytes());
+        buf[32..36].copy_from_slice(&rtt_ms.to_ne_bytes());
+        buf[36..].copy_from_slice(echoed);
+        buf
+    }
+
+    /// The echoed payload our own probes carry (checked on Echo Replies).
+    fn own_payload(sequence: u16) -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(&(std::process::id() as u16).to_be_bytes());
+        data.extend_from_slice(&sequence.to_be_bytes());
+        data.extend_from_slice(b"ftr-windows-padding");
+        data.resize(32, 0);
+        data
+    }
+
+    #[test]
+    fn test_struct_layout_matches_spike_observations() {
+        // Guard against windows-sys layout drift: the spike measured
+        // these sizes live (ICMPV6_ECHO_REPLY_LH=36, IPV6_ADDRESS_EX=26).
+        assert_eq!(mem::size_of::<ICMPV6_ECHO_REPLY_LH>(), 36);
+        assert_eq!(
+            mem::size_of::<windows_sys::Win32::NetworkManagement::IpHelper::IPV6_ADDRESS_EX>(),
+            26
+        );
+    }
+
+    #[test]
+    fn test_parse_hop_limit_exceeded_reply() {
+        let router: Ipv6Addr = "2001:db8:1::1".parse().expect("addr parses");
+        // Time Exceeded does not echo the payload (spike-observed zeros)
+        let buf = synthetic_reply(router, IP_HOP_LIMIT_EXCEEDED, 7, &[0u8; 32]);
+
+        let resp = parse_reply(&buf, 42, 3, Duration::from_millis(9)).expect("parses");
+        assert_eq!(resp.from_addr, IpAddr::V6(router));
+        assert_eq!(resp.sequence, 42);
+        assert_eq!(resp.ttl, 3);
+        assert!(!resp.is_destination);
+        assert!(!resp.is_timeout);
+        assert_eq!(resp.rtt, Duration::from_millis(7));
+    }
+
+    #[test]
+    fn test_parse_destination_echo_reply() {
+        let dest: Ipv6Addr = "2001:4860:4860::8888".parse().expect("addr parses");
+        let buf = synthetic_reply(dest, IP_SUCCESS, 3, &own_payload(7));
+
+        let resp = parse_reply(&buf, 7, 30, Duration::from_millis(4)).expect("parses");
+        assert_eq!(resp.from_addr, IpAddr::V6(dest));
+        assert!(resp.is_destination);
+        assert!(!resp.is_timeout);
+        assert_eq!(resp.rtt, Duration::from_millis(3));
+    }
+
+    #[test]
+    fn test_parse_uses_elapsed_for_zero_rtt() {
+        let dest: Ipv6Addr = "::1".parse().expect("addr parses");
+        let buf = synthetic_reply(dest, IP_SUCCESS, 0, &own_payload(1));
+
+        let resp = parse_reply(&buf, 1, 1, Duration::from_micros(250)).expect("parses");
+        assert_eq!(resp.rtt, Duration::from_micros(250));
+    }
+
+    #[test]
+    fn test_parse_rejects_foreign_echo_reply() {
+        let dest: Ipv6Addr = "::1".parse().expect("addr parses");
+        // Same sequence but an identifier from some other process
+        let mut payload = own_payload(5);
+        let foreign_id = (std::process::id() as u16).wrapping_add(1);
+        payload[0..2].copy_from_slice(&foreign_id.to_be_bytes());
+        let buf = synthetic_reply(dest, IP_SUCCESS, 1, &payload);
+
+        let err = parse_reply(&buf, 5, 1, Duration::from_millis(1))
+            .expect_err("foreign identifier must be rejected");
+        assert!(matches!(err, TracerouteError::SocketError(_)));
+    }
+
+    #[test]
+    fn test_parse_timeout_status_reply() {
+        let buf = synthetic_reply(Ipv6Addr::UNSPECIFIED, IP_REQ_TIMED_OUT, 0, &[0u8; 32]);
+
+        let resp = parse_reply(&buf, 9, 5, Duration::from_millis(100)).expect("parses");
+        assert!(resp.is_timeout);
+        assert!(!resp.is_destination);
+        assert_eq!(resp.from_addr, IpAddr::V6(Ipv6Addr::UNSPECIFIED));
+    }
+
+    #[test]
+    fn test_parse_rejects_short_buffer() {
+        let buf = vec![0u8; mem::size_of::<ICMPV6_ECHO_REPLY_LH>() - 1];
+        assert!(parse_reply(&buf, 0, 1, Duration::ZERO).is_err());
+    }
+
+    #[test]
+    fn test_reply_words_network_byte_order() {
+        // The spike observed 2001:4860:4860::8888 arriving as bytes
+        // 20 01 48 60 48 60 00 .. 88 88 at the word field; reading those
+        // bytes as native u16s and re-serializing must round-trip.
+        let expected: Ipv6Addr = "2001:4860:4860::8888".parse().expect("addr parses");
+        let wire: [u8; 16] = expected.octets();
+        let mut words = [0u16; 8];
+        for (i, w) in words.iter_mut().enumerate() {
+            *w = u16::from_ne_bytes([wire[i * 2], wire[i * 2 + 1]]);
+        }
+        assert_eq!(ipv6_from_reply_words(words), expected);
+    }
+}

--- a/tests/error_handling_test.rs
+++ b/tests/error_handling_test.rs
@@ -82,12 +82,13 @@ async fn test_ipv6_target_platform_behavior() {
     let ftr_instance = ftr::Ftr::new();
     let result = ftr_instance.trace_with_config(config).await;
 
-    // macOS (unprivileged DGRAM ICMPv6) and Linux (unprivileged UDP with
-    // IPV6_RECVERR) both trace IPv6 without root: a loopback trace reaches
-    // ::1 in one hop, classified as LAN. The BSDs trace IPv6 only via raw
-    // ICMPv6 (root required); platforms without IPv6 probe support must
-    // surface the typed Ipv6NotSupported error.
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    // macOS (unprivileged DGRAM ICMPv6), Linux (unprivileged UDP with
+    // IPV6_RECVERR), and Windows (Icmp6SendEcho2, no elevation) all trace
+    // IPv6 without root: a loopback trace reaches ::1 in one hop,
+    // classified as LAN. The BSDs trace IPv6 only via raw ICMPv6 (root
+    // required); platforms without IPv6 probe support must surface the
+    // typed Ipv6NotSupported error.
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     {
         let trace = result.expect("IPv6 loopback trace should succeed unprivileged");
         assert!(trace.destination_reached, "::1 must be reachable");
@@ -127,6 +128,7 @@ async fn test_ipv6_target_platform_behavior() {
     #[cfg(not(any(
         target_os = "macos",
         target_os = "linux",
+        target_os = "windows",
         target_os = "freebsd",
         target_os = "openbsd",
         target_os = "netbsd",

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -282,16 +282,17 @@ async fn test_error_types() {
         result
     );
 
-    // IPv6 targets: unprivileged DGRAM ICMPv6 traceroute on macOS and
-    // unprivileged UDP + IPV6_RECVERR on Linux; the typed Ipv6NotSupported
-    // error on platforms without v6 probe support.
+    // IPv6 targets: unprivileged DGRAM ICMPv6 traceroute on macOS,
+    // unprivileged UDP + IPV6_RECVERR on Linux, and the unprivileged
+    // Icmp6SendEcho2 API on Windows; the typed Ipv6NotSupported error on
+    // platforms without v6 probe support.
     let result = trace("::1").await;
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     {
         let v6_trace = result.expect("IPv6 loopback trace should succeed unprivileged");
         assert!(v6_trace.destination_reached);
     }
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     assert!(
         matches!(&result, Err(TracerouteError::Ipv6NotSupported)),
         "Expected Ipv6NotSupported error, got: {:?}",


### PR DESCRIPTION
Windows was the last platform without IPv6 traceroute after v0.9.0. This PR closes that gap with the IP Helper `Icmp6CreateFile`/`Icmp6SendEcho2`/`Icmp6ParseReplies` API, mirroring the proven v4 `WindowsAsyncIcmpSocket` design (event handle per probe, `spawn_blocking` waiter, and the Tokio-vs-Windows timeout-buffer logic from `docs/WINDOWS_ASYNC_FINDINGS.md`). No elevation required, same as v4. `-6` now works on every supported platform.

## Spike-first validation (live, before implementation)

`examples/spike_windows_v6.rs` (permanent in-repo diagnostic) ran in a Windows 11 ARM64 VM with native IPv6 (Sonic fiber, bridged) and confirmed every hypothesis from `docs/IPV6_DESIGN.md`, now recorded there as a "Validated findings (Windows)" section:

- The **required source `SOCKADDR_IN6`** accepts the unspecified `::` with `AF_INET6` — the stack picks the source; no interface enumeration/`GetBestInterfaceEx` needed
- `IP_OPTION_INFORMATION.Ttl` sets the hop limit; expired probes return `Status = IP_HOP_LIMIT_EXCEEDED` (11013) with the router's address
- `ICMPV6_ECHO_REPLY_LH` layout verified by hex dump: 36 bytes, packed 26-byte `IPV6_ADDRESS_EX` (address `[u16;8]` words in **network byte order** at byte 6), `Status` at 28, `RoundTripTime` at 32, echoed request payload at 36 for Echo Replies only (Time Exceeded doesn't echo — same asymmetry as v4)
- Timeout: event still signals; `Icmp6ParseReplies` returns 0 with `GetLastError() = IP_REQ_TIMED_OUT` (11010)

## Live results from the VM

`ftr -6 -v google.com` (abridged):

```
Using Windows ICMPv6 API mode for traceroute
 1 [LAN   ] 2001:5a8:4681:2c00::1 6.586 ms [AS46375 - AS-SONICTELECOM - Sonic Telecom LLC, US]
 2 [ISP   ] 2001:5a8:657:21::f1:4 6.553 ms [AS46375 ...]
 4 [ISP   ] ae5.cr3.colaca01.sonic.net (2001:5a8:5:403f::e3:b) 3.000 ms [AS46375 ...]
13 [ISP   ] 100.ae1.nrd1.equinix-sj.sonic.net (2001:5a8:5:403f::8a:a) 3.000 ms [AS46375 ...]
14 [DESTINATION] 2001:4860:1:1::3ab6 2.000 ms [AS15169 - GOOGLE - Google LLC, US]
17 [DESTINATION] sfo07s17-in-x0e.1e100.net (2607:f8b0:4005:80a::200e) 3.000 ms [AS15169 ...]

Detected public IP: 2001:5a8:4681:2c00:404:f2c5:dda2:1d1d
Detected ISP: AS46375 (AS-SONICTELECOM - Sonic Telecom LLC)
Destination ASN: AS15169 (GOOGLE - Google LLC, US)
```

Also verified in the VM: `ftr -6 ::1` loopback, `ftr 8.8.8.8` v4 regression trace, and the full lib test suite (231 passed, including the 8 new `windows_v6` reply-parse unit tests against synthetic spike-verified buffers).

## Implementation notes

- `src/socket/windows_v6.rs`: new socket; replies go through `Icmp6ParseReplies` per the async API contract (0 parsed replies maps to a timeout response); echo-reply id/seq verification uses the payload echoed at offset 36; `read_unaligned` for the reply struct (Vec buffers have 1-byte alignment)
- `src/socket/factory.rs`: Windows V6 arm dispatches to the new socket; explicit UDP protocol preference returns typed `NotImplemented` (consistent with macOS/BSD)
- **Additive API only**: reuses `ProbeMode::WindowsIcmp` — no new public enum variants
- CI note: GitHub's Windows runners can't receive ICMP (Azure blocks it), so live behavior there degrades to compile + unit tests, matching the existing v4 pattern

## Lint debt payoff

`cargo clippy --target x86_64-pc-windows-msvc --all-targets` carried ~16 dead-code warnings invisible to CI (whose clippy job runs on Ubuntu): unused v4 raw-ICMP codec helpers on Windows, spike RFC constants under stub mains, and an unused `new_with_config` constructor. All resolved — the windows-msvc target is now clean under `-D warnings`. **The durable fix is adding a windows-target clippy cross-check to CI** (tracked in the improvement plan); this PR clears the baseline for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)