### PR TITLE
ci: Automate Homebrew tap formula bump on release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,42 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+  # Update the Homebrew tap formula (only when release is published, like crates.io)
+  publish-homebrew:
+    name: Update Homebrew Tap
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease
+    steps:
+      - name: Compute release tarball SHA256
+        id: tarball
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          curl -sL --fail "https://github.com/${{ github.repository }}/archive/refs/tags/${TAG}.tar.gz" -o ftr.tar.gz
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "sha256=$(sha256sum ftr.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout homebrew-ftr tap
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: dweekly/homebrew-ftr
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Update formula and push
+        run: |
+          VERSION="${{ steps.tarball.outputs.version }}"
+          SHA256="${{ steps.tarball.outputs.sha256 }}"
+          sed -i -E "s|^  url \".*\"|  url \"https://github.com/dweekly/ftr/archive/refs/tags/v${VERSION}.tar.gz\"|" ftr.rb
+          sed -i -E "s|^  sha256 \".*\"|  sha256 \"${SHA256}\"|" ftr.rb
+          if git diff --quiet ftr.rb; then
+            echo "Formula already at v${VERSION}, nothing to do"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "Update ftr to v${VERSION}"
+          git push
+
   build-deb:
     name: Build Debian Package
     runs-on: ubuntu-latest

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -107,17 +107,27 @@ When you push the tag, the following automated processes will run:
    - Link to the full CHANGELOG
    - Credit contributors
 
-4. **Publish the release** (this triggers the crates.io publish)
+4. **Publish the release** (this triggers the crates.io publish and the Homebrew tap update)
 
 ### 7. Verify the Release
 
 After publishing:
 1. Check that the release appears on crates.io
-2. Test installation methods:
+2. Check that [dweekly/homebrew-ftr](https://github.com/dweekly/homebrew-ftr) got the automated formula bump commit
+3. Test installation methods:
    - `cargo install ftr`
+   - `brew upgrade ftr` (builds from source)
    - Debian package installation
    - Windows binary execution
-3. Update any documentation that references the version
+4. Update any documentation that references the version
+
+## Required Secrets
+
+The release workflow depends on these repository secrets:
+- `CARGO_REGISTRY_TOKEN` — crates.io API token for `cargo publish`
+- `HOMEBREW_TAP_TOKEN` — GitHub personal access token with push access to
+  `dweekly/homebrew-ftr` (fine-grained PAT scoped to that repo with
+  Contents: read/write). The default `GITHUB_TOKEN` cannot push cross-repo.
 
 ## Security Considerations
 
@@ -162,6 +172,15 @@ If the crates.io publish fails:
    - Version already exists on crates.io
    - Missing or invalid API token
    - Cargo.toml metadata issues
+
+### Homebrew tap update fails
+
+If the `Update Homebrew Tap` job fails:
+1. Check that the `HOMEBREW_TAP_TOKEN` secret exists and has not expired
+2. Fall back to a manual bump in `dweekly/homebrew-ftr`: update the `url` and
+   `sha256` lines in `ftr.rb` (download the tarball first, then
+   `shasum -a 256 <file>` — don't pipe curl into shasum; that produced a
+   wrong hash for v0.6.0) and push
 
 ## Emergency Release Process
 


### PR DESCRIPTION
## Why

The Homebrew tap (`dweekly/homebrew-ftr`) was never part of the automated release pipeline and wasn't in `RELEASE_PROCESS.md` either — every bump was a hand-authored commit. It fell 4 releases behind: the formula served v0.6.0 while crates.io had v0.10.0. (The formula has since been manually bumped to v0.10.0.)

## What

- New `publish-homebrew` job in `release.yml`, gated the same way as the crates.io publish (release published, not prerelease): downloads the tag's source tarball, computes its SHA256, rewrites `url`/`sha256` in the tap's `ftr.rb`, and pushes. No-ops if the formula is already current.
- `RELEASE_PROCESS.md`: documents the Homebrew channel in pipeline/verification steps, adds a Required Secrets section, and a manual-fallback troubleshooting entry (including the download-then-hash gotcha that bit the v0.6.0 bump).

## Action required before this works

Add a `HOMEBREW_TAP_TOKEN` repository secret: a fine-grained PAT scoped to `dweekly/homebrew-ftr` with Contents read/write. The default `GITHUB_TOKEN` can't push cross-repo.

## Testing

- YAML validated; sed patterns anchored to `^  url`/`^  sha256` so the `head` line is untouched (verified against the live formula)
- The job path itself can only be exercised by the next real release publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)