### PR TITLE
docs: Fix stale IPv6 platform claims in rustdoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@
 //!     
 //!     // Other structured errors
 //!     Err(TracerouteError::Ipv6NotSupported) => {
-//!         eprintln!("IPv6 targets are not yet supported");
+//!         eprintln!("IPv6 targets are not supported on this platform");
 //!     }
 //!     Err(TracerouteError::ResolutionError(msg)) => {
 //!         eprintln!("DNS resolution failed: {}", msg);

--- a/src/traceroute.rs
+++ b/src/traceroute.rs
@@ -13,7 +13,7 @@
 //!
 //! - **`InsufficientPermissions`** - Includes what permissions are needed and suggestions
 //! - **`NotImplemented`** - Feature not yet implemented (e.g., TCP traceroute)
-//! - **`Ipv6NotSupported`** - IPv6 targets not yet supported
+//! - **`Ipv6NotSupported`** - IPv6 targets not supported on this platform
 //! - **`ResolutionError`** - DNS resolution failed
 //! - **`SocketError`** - Socket creation/operation failed
 //! - **`ConfigError`** - Invalid configuration

--- a/src/traceroute/config.rs
+++ b/src/traceroute/config.rs
@@ -61,11 +61,13 @@ impl Default for TimingConfig {
 /// # Default (`Auto`)
 ///
 /// `Auto` prefers IPv4 when a host has both A and AAAA records, and uses
-/// IPv6 only when the host is v6-only. This is a deliberately conservative
-/// default while IPv6 probing is new (currently macOS-only): a dual-stack
-/// host keeps yielding exactly the same trace as previous ftr releases on
-/// every platform, and platforms without IPv6 probe support quietly keep
-/// working. Pass `V6` (CLI `-6`) to opt in for dual-stack hosts.
+/// IPv6 only when the host is v6-only. IPv6 probing is supported on every
+/// platform (macOS/Linux/BSD since 0.9.0, Windows since 0.10.0); the
+/// v4-first default is kept for behavioral compatibility — a dual-stack
+/// host yields exactly the same trace as pre-0.9 ftr releases. This is
+/// deliberately not Happy Eyeballs: the OS may prefer IPv6 for its own
+/// connections to the same host. Pass `V6` (CLI `-6`) to opt in for
+/// dual-stack hosts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum PreferredFamily {
     /// Only resolve to IPv4; error if the host has no A records

--- a/src/traceroute/error.rs
+++ b/src/traceroute/error.rs
@@ -76,7 +76,9 @@ pub enum TracerouteError {
         feature: String,
     },
 
-    /// IPv6 targets are not yet supported
+    /// IPv6 targets are not supported on this platform (all tier-1
+    /// platforms — macOS, Linux, Windows, the BSDs — support IPv6; only
+    /// other OSes return this)
     #[error("IPv6 targets are not yet supported")]
     Ipv6NotSupported,
 


### PR DESCRIPTION
Fixes rustdoc claims that predate the v0.9/v0.10 IPv6 rollout:

- `PreferredFamily` (`config.rs`): the `Auto` rationale said IPv6 probing was "currently macOS-only" and cited platforms without v6 support — both obsolete since v0.10.0 completed Windows. Rewritten: v4-first is kept purely for behavioral compatibility with pre-0.9 traces, and explicitly noted as not-Happy-Eyeballs. 
- `Ipv6NotSupported` doc comments in `error.rs`, `traceroute.rs`, and the `lib.rs` example: clarified this now only fires on non-tier-1 platforms.

Doc comments only — no `#[error]` message strings or behavior changed. Two things noticed but deliberately left alone: the `#[error("IPv6 targets are not yet supported")]` runtime string is also slightly stale, and `ProviderError::UnsupportedIpVersion` (`public_ip/providers.rs`) is defined but never constructed (removing it is semver-breaking). Both are separate conversations.

Verified: `cargo fmt`, `clippy --all-targets -D warnings`, `cargo doc` with `-Dwarnings`, and all 28 doctests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)